### PR TITLE
return on error instead of continue

### DIFF
--- a/pkg/actions/mongodb.go
+++ b/pkg/actions/mongodb.go
@@ -216,13 +216,13 @@ func (a *MongoDBQuery) Execute(ctx context.Context, cfg map[string]any) error {
 		command, err := bson.Marshal(query)
 		if err != nil {
 			logger.FromContext(ctx).Warn("failed to marshal query", zap.Error(err))
-			continue
+			return err
 		}
 
 		cursor, err = db.RunCommandCursor(ctx, command)
 		if err != nil {
 			logger.FromContext(ctx).Warn("failed to execute query", zap.Error(err))
-			continue
+			return err
 		}
 
 		var results []bson.M
@@ -230,7 +230,7 @@ func (a *MongoDBQuery) Execute(ctx context.Context, cfg map[string]any) error {
 			var result bson.M
 			if err := cursor.Decode(&result); err != nil {
 				logger.FromContext(ctx).Error("failed to decode cursor", zap.Error(err))
-				continue
+				return err
 			}
 			results = append(results, result)
 		}
@@ -238,7 +238,7 @@ func (a *MongoDBQuery) Execute(ctx context.Context, cfg map[string]any) error {
 		// Check for errors during cursor iteration
 		if err := cursor.Err(); err != nil {
 			logger.FromContext(ctx).Error("failed to iterate cursor", zap.Error(err))
-			continue
+			return err
 		}
 
 		// Print the results

--- a/pkg/actions/mysql.go
+++ b/pkg/actions/mysql.go
@@ -139,9 +139,8 @@ func (action *MysqlQuery) Execute(ctx context.Context, cfg map[string]any) error
 		now := time.Now()
 		rows, looperr := db.QueryContext(ctx, config.Query)
 		if looperr != nil {
-			logger.FromContext(ctx).Warn("failed to execute query", zap.Error(err))
-			err = looperr
-			continue
+			logger.FromContext(ctx).Warn("failed to execute query", zap.Error(looperr))
+			return looperr
 		}
 
 		cols, err := rows.Columns()

--- a/pkg/actions/postgresql.go
+++ b/pkg/actions/postgresql.go
@@ -123,9 +123,8 @@ func (action *PostgresqlQuery) Execute(ctx context.Context, cfg map[string]any) 
 		now := time.Now()
 		rows, looperr := db.QueryContext(ctx, config.Query)
 		if looperr != nil {
-			logger.FromContext(ctx).Warn("failed to execute query", zap.Error(err))
-			err = looperr
-			continue
+			logger.FromContext(ctx).Warn("failed to execute query", zap.Error(looperr))
+			return looperr
 		}
 
 		cols, err := rows.Columns()

--- a/plans/examples/postgresql.yaml
+++ b/plans/examples/postgresql.yaml
@@ -7,6 +7,7 @@ phases:
         - instances: 1
           duration: 5m
           delay: 10ms
+          timeout: 30s
 
     workload:
       actions:

--- a/plans/more_requests.yaml
+++ b/plans/more_requests.yaml
@@ -7,6 +7,7 @@ phases:
         - instances: 10
           duration: 60h
           delay: 0ms
+          timeout: 30s
 
     workload:
       actions:


### PR DESCRIPTION
# Description

return on error instead of continue and also used increasted client timeout for postgres pg_sleep plans

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
