### PR TITLE
[DEV-834]: Instrument Kafka Produce/Consume non Datadog use-case

### DIFF
--- a/docs/kafka-setup.md
+++ b/docs/kafka-setup.md
@@ -1,0 +1,119 @@
+
+# Setup local (strimzi) Kafka cluster
+
+## Prerequisites
+
+### Edit [helm/video/values.yaml](../helm/video/values.yaml)
+
+#### Set `datadog.enabled` to `false`
+
+#### Configure Consumer Clients
+
+There are (as of writing) 3 `background_services`
+
+    - name: "encoder-data-broker-consumer"
+    - name: "upload-message-broker-consumer"
+    - name: "inventory-message-broker-consumer"
+
+for each of these they need to be configured to use the Kafka cluster, e.g.
+```yaml
+  - name: "encoder-data-broker-consumer"
+    type: kafka-consumer
+    config:
+      tracing_service_name: data-broker
+      brokers:
+        - "chaosmania-kafka-cluster-kafka-brokers:9092"
+      username: "" # TODO
+      password: "" # TODO
+      tls_enable: false
+      sasl_enable: false
+      topic: test1
+      group: encoder-group
+```
+**Notes:** 
+  - `type` should be `kafka-consumer` here. (options are: `rabbitmq-consumer` | `kafka-producer`)
+  - `username` and `password` are not used in the current setup.
+  - `tls_enable` and `sasl_enable` are not used in the current setup.
+  - `topic` and `group` will defer depending on the producer - consumer relationship/script.
+  - `tracing_service_name` may not be important as we should be using the `peer.service` derived from the broker(s).
+
+#### Configure Producer Clients
+
+Similar to `background_services` config, under the `services:` block edit the:
+```yaml
+  - name: "data-broker-producer"
+    type: kafka-producer
+    config:
+      tracing_service_name: data-broker
+      brokers:
+        - "chaosmania-kafka-cluster-kafka-brokers:9092"
+      username: "" # TODO
+      password: "" # TODO
+      tls_enable: false
+      sasl_enable: false
+      topic: test1
+```
+
+#### Configure OTLP (optional)
+
+example:
+```yaml
+otlp:
+  enabled: true
+  endpoint: "http://otel-collector.otel-collector.svc.cluster.local:4317"
+```
+
+---
+
+## Install Strimzi Kafka Operator
+
+There are some convenient scripts in the `scripts` directory to help with managing this.  
+- [create_kafka_cluster.sh](../scripts/create_kafka_cluster.sh)
+- [delete_kafka_cluster.sh](../scripts/delete_kafka_cluster.sh)
+
+#### Edit the `create_kafka_cluster.sh` script
+
+- set `NS` var to the namespace you want to install the Kafka cluster into. (default: `chaosmania`)
+- execute `./scripts/create_kafka_cluster.sh` to install the Kafka cluster.
+
+You _should_ end up with the following resources:
+
+`kubectl -n chaosmania get pods`
+```kubectl
+NAME                                                          READY  
+| chaosmania-kafka-cluster-chaosmania-kafka-pool-0          ●   1/1    
+│ chaosmania-kafka-cluster-chaosmania-kafka-pool-1          ●   1/1    
+│ chaosmania-kafka-cluster-chaosmania-kafka-pool-2          ●   1/1    
+│ chaosmania-kafka-cluster-entity-operator-b89d77fd9-szt22  ●   1/1 
+| strimzi-cluster-operator-868f55785f-z5hqj                 ●   1/1    
+```
+
+`kubectl -n chaosmania get svc`
+```kubectl
+chaosmania-kafka-cluster-kafka-bootstrap   ClusterIP   10.96.45.138    <none>        9091/TCP,9092/TCP,9093/TCP                     85m
+chaosmania-kafka-cluster-kafka-brokers     ClusterIP   None            <none>        9090/TCP,9091/TCP,8443/TCP,9092/TCP,9093/TCP   85m
+```
+**Notes:** 
+- The `...-kafka-brokers` service is what we use for the `brokers` lists config in the `values.yaml` file.
+
+`kubectl -n chaosmania get kafkatopics`
+```kubectl
+NAME                       CLUSTER                    PARTITIONS   REPLICATION FACTOR   READY
+inventory-video-encoding   chaosmania-kafka-cluster   1            3                    True
+test1                      chaosmania-kafka-cluster   1            3                    True
+upload-video-encoding      chaosmania-kafka-cluster   1            3                    True
+```
+
+---
+
+## Run the `chaosmania` helm `video` deployment
+
+Something like this (note the `--set image.tag=xxxx` or just use `latest`):
+- `helm upgrade --install --create-namespace --namespace chaosmania video ./helm/video --set image.tag=brandon`
+
+---
+
+## Run the plan/plans you want to load
+
+- open [update_video_clients.sh](../update_video_clients.sh) and set the variables appropriately.
+- execute `./update_video_clients.sh` to run the plan(s) via helm deployments

--- a/helm/video/values.yaml
+++ b/helm/video/values.yaml
@@ -50,7 +50,7 @@ background_services:
     config:
       tracing_service_name: data-broker
       brokers:
-        - "super-heroes-kafka-brokers:9092"
+        - "chaosmania-kafka-cluster-kafka-brokers:9092"
       username: "" # TODO
       password: "" # TODO
       tls_enable: false
@@ -102,7 +102,7 @@ background_services:
     config:
       tracing_service_name: data-broker
       brokers:
-        - "super-heroes-kafka-brokers:9092"
+        - "chaosmania-kafka-cluster-kafka-brokers:9092"
       username: "" # TODO
       password: "" # TODO
       tls_enable: false
@@ -130,7 +130,7 @@ background_services:
     config:
       tracing_service_name: data-broker
       brokers:
-        - "super-heroes-kafka-brokers:9092"
+        - "chaosmania-kafka-cluster-kafka-brokers:9092"
       username: "" # TODO
       password: "" # TODO
       tls_enable: false
@@ -155,6 +155,17 @@ background_services:
 
 
 services:
+  - name: "data-broker-producer"
+    type: kafka-producer
+    config:
+      tracing_service_name: data-broker
+      brokers:
+        - "chaosmania-kafka-cluster-kafka-brokers:9092"
+      username: "" # TODO
+      password: "" # TODO
+      tls_enable: false
+      sasl_enable: false
+
   - name: auth-cache
     type: redis
     config:
@@ -184,23 +195,6 @@ services:
       password: postgres
       port: 5432
       user: postgres
-
-  - name: "data-broker-producer"
-    type: kafka-producer
-    config:
-      tracing_service_name: data-broker
-      brokers:
-        - "super-heroes-kafka-brokers:9092" # TODO
-      username: "" # TODO
-      password: "" # TODO
-      tls_enable: false
-      sasl_enable: false
-
-  - name: "message-broker-producer"
-    type: rabbitmq-producer
-    config:
-      tracing_service_name: message-broker
-      url: "amqp://guest:guest@message-broker:5672/"
 
   - name: "storage"
     type: "minio"

--- a/helm/video/values.yaml
+++ b/helm/video/values.yaml
@@ -17,7 +17,7 @@ serviceMonitor:
 
 otlp:
   enabled: false
-  endpoint: "" # "http://opentelemetry-collector.default:4318" ## or http://tempo.monitoring:4318
+  endpoint: "" # http://tempo.monitoring:4318
   insecure: true
 
 datadog:
@@ -143,23 +143,6 @@ background_services:
 
 
 services:
-  - name: "data-broker-producer"
-    type: kafka-producer
-    config:
-      tracing_service_name: data-broker
-      brokers:
-        - "chaosmania-kafka-cluster-kafka-brokers:9092"
-      username: "" # TODO
-      password: "" # TODO
-      tls_enable: false
-      sasl_enable: false
-
-  - name: "message-broker-producer"
-    type: rabbitmq-producer
-    config:
-      tracing_service_name: message-broker
-      url: "amqp://guest:guest@message-broker:5672/"
-
   - name: auth-cache
     type: redis
     config:
@@ -189,6 +172,23 @@ services:
       password: postgres
       port: 5432
       user: postgres
+
+  - name: "data-broker-producer"
+    type: kafka-producer
+    config:
+      tracing_service_name: data-broker
+      brokers:
+        - "" # TODO
+      username: "" # TODO
+      password: "" # TODO
+      tls_enable: true
+      sasl_enable: true
+
+  - name: "message-broker-producer"
+    type: rabbitmq-producer
+    config:
+      tracing_service_name: message-broker
+      url: "amqp://guest:guest@message-broker:5672/"
 
   - name: "storage"
     type: "minio"

--- a/helm/video/values.yaml
+++ b/helm/video/values.yaml
@@ -21,7 +21,7 @@ otlp:
   insecure: true
 
 datadog:
-  enabled: false
+  enabled: true
 
 hpa:
   enabled: false
@@ -50,11 +50,11 @@ background_services:
     config:
       tracing_service_name: data-broker
       brokers:
-        - "chaosmania-kafka-cluster-kafka-brokers:9092"
+        - "" # TODO
       username: "" # TODO
       password: "" # TODO
-      tls_enable: false
-      sasl_enable: false
+      tls_enable: true
+      sasl_enable: true
       topic: test1
       group: encoder-group
       script: |
@@ -65,7 +65,7 @@ background_services:
           var raw_data = data.raw_data;
 
           // Update the video status to encoding
-          message_broker = ctx.get_service("data-broker-producer");
+          message_broker = ctx.get_service("message-broker-producer");
           msg = JSON.stringify({
               "video_id": video_id,
               "status": "encoding"
@@ -98,17 +98,11 @@ background_services:
   # - It consumes messages from the message broker (the video status, send by the encoder)
   # - Updates the video status in the upload database
   - name: "upload-message-broker-consumer"
-    type: kafka-consumer
+    type: rabbitmq-consumer
     config:
-      tracing_service_name: data-broker
-      brokers:
-        - "chaosmania-kafka-cluster-kafka-brokers:9092"
-      username: "" # TODO
-      password: "" # TODO
-      tls_enable: false
-      sasl_enable: false
-      topic: upload-video-encoding
-      group: upload-group
+      tracing_service_name: message-broker
+      url: "amqp://guest:guest@message-broker:5672/"
+      queue: "upload-video-encoding"
       script: |
         function run() {
           msg = ctx.get_message()
@@ -126,17 +120,11 @@ background_services:
   # - It consumes messages from the message broker (the video status, send by the encoder)
   # - Updates the video status in the inventory database
   - name: "inventory-message-broker-consumer"
-    type: kafka-consumer
+    type: rabbitmq-consumer
     config:
-      tracing_service_name: data-broker
-      brokers:
-        - "chaosmania-kafka-cluster-kafka-brokers:9092"
-      username: "" # TODO
-      password: "" # TODO
-      tls_enable: false
-      sasl_enable: false
-      topic: "inventory-video-encoding"
-      group: inventory-group
+      tracing_service_name: message-broker
+      url: "amqp://guest:guest@message-broker:5672/"
+      queue: "inventory-video-encoding"
       script: |
         function run() {
           msg = ctx.get_message()
@@ -165,6 +153,12 @@ services:
       password: "" # TODO
       tls_enable: false
       sasl_enable: false
+
+  - name: "message-broker-producer"
+    type: rabbitmq-producer
+    config:
+      tracing_service_name: message-broker
+      url: "amqp://guest:guest@message-broker:5672/"
 
   - name: auth-cache
     type: redis

--- a/helm/video/values.yaml
+++ b/helm/video/values.yaml
@@ -17,11 +17,11 @@ serviceMonitor:
 
 otlp:
   enabled: false
-  endpoint: "" # http://tempo.monitoring:4318
+  endpoint: "" # "http://opentelemetry-collector.default:4318" ## or http://tempo.monitoring:4318
   insecure: true
 
 datadog:
-  enabled: true
+  enabled: false
 
 hpa:
   enabled: false
@@ -49,12 +49,12 @@ background_services:
     type: kafka-consumer
     config:
       tracing_service_name: data-broker
-      brokers: 
-        - "" # TODO
+      brokers:
+        - "super-heroes-kafka-brokers:9092"
       username: "" # TODO
       password: "" # TODO
-      tls_enable: true
-      sasl_enable: true
+      tls_enable: false
+      sasl_enable: false
       topic: test1
       group: encoder-group
       script: |
@@ -65,7 +65,7 @@ background_services:
           var raw_data = data.raw_data;
 
           // Update the video status to encoding
-          message_broker = ctx.get_service("message-broker-producer");
+          message_broker = ctx.get_service("data-broker-producer");
           msg = JSON.stringify({
               "video_id": video_id,
               "status": "encoding"
@@ -98,11 +98,17 @@ background_services:
   # - It consumes messages from the message broker (the video status, send by the encoder)
   # - Updates the video status in the upload database
   - name: "upload-message-broker-consumer"
-    type: rabbitmq-consumer
+    type: kafka-consumer
     config:
-      tracing_service_name: message-broker
-      url: "amqp://guest:guest@message-broker:5672/"
-      queue: "upload-video-encoding"
+      tracing_service_name: data-broker
+      brokers:
+        - "super-heroes-kafka-brokers:9092"
+      username: "" # TODO
+      password: "" # TODO
+      tls_enable: false
+      sasl_enable: false
+      topic: upload-video-encoding
+      group: upload-group
       script: |
         function run() {
           msg = ctx.get_message()
@@ -120,11 +126,17 @@ background_services:
   # - It consumes messages from the message broker (the video status, send by the encoder)
   # - Updates the video status in the inventory database
   - name: "inventory-message-broker-consumer"
-    type: rabbitmq-consumer
+    type: kafka-consumer
     config:
-      tracing_service_name: message-broker
-      url: "amqp://guest:guest@message-broker:5672/"
-      queue: "inventory-video-encoding"
+      tracing_service_name: data-broker
+      brokers:
+        - "super-heroes-kafka-brokers:9092"
+      username: "" # TODO
+      password: "" # TODO
+      tls_enable: false
+      sasl_enable: false
+      topic: "inventory-video-encoding"
+      group: inventory-group
       script: |
         function run() {
           msg = ctx.get_message()
@@ -177,12 +189,12 @@ services:
     type: kafka-producer
     config:
       tracing_service_name: data-broker
-      brokers: 
-        - "" # TODO
+      brokers:
+        - "super-heroes-kafka-brokers:9092" # TODO
       username: "" # TODO
       password: "" # TODO
-      tls_enable: true
-      sasl_enable: true
+      tls_enable: false
+      sasl_enable: false
 
   - name: "message-broker-producer"
     type: rabbitmq-producer

--- a/kubernetes/strimzi-kafka/exporters/prometheus_kafka_values.yaml
+++ b/kubernetes/strimzi-kafka/exporters/prometheus_kafka_values.yaml
@@ -1,0 +1,22 @@
+kafkaServer:
+  - super-heroes-kafka-brokers.chaosmania.svc.cluster.local:9092
+
+service:
+  annotations:
+    prometheus.io/port: "9308"
+    prometheus.io/scrape: "true"
+
+prometheus:
+  serviceMonitor:
+    enabled: true
+    namespace: chaosmania
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: false
+  # Specifies whether a PodSecurityPolicy should be created
+  pspEnabled: false
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: false

--- a/kubernetes/strimzi-kafka/exporters/prometheus_kafka_values.yaml
+++ b/kubernetes/strimzi-kafka/exporters/prometheus_kafka_values.yaml
@@ -1,5 +1,5 @@
 kafkaServer:
-  - super-heroes-kafka-brokers.chaosmania.svc.cluster.local:9092
+  - chaosmania-kafka-cluster-kafka-brokers:9092
 
 service:
   annotations:

--- a/kubernetes/strimzi-kafka/kafka-cluster-descriptor.yaml
+++ b/kubernetes/strimzi-kafka/kafka-cluster-descriptor.yaml
@@ -1,0 +1,59 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: chaosmania-kafka-pool
+  labels:
+    strimzi.io/cluster: chaosmania-kafka-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+    - broker
+  storage:
+    type: ephemeral
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: chaosmania-kafka-cluster
+  annotations:
+    strimzi.io/node-pools: enabled
+    strimzi.io/kraft: enabled
+spec:
+  kafka:
+    version: 3.6.1
+    metadataVersion: 3.6-IV2
+    # The replicas field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
+    # But it will be ignored when Kafka Node Pools are used
+    replicas: 3
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      inter.broker.protocol.version: '3.6'
+    # The storage field is required by the Kafka CRD schema while the KafkaNodePools feature gate is in alpha phase.
+    # But it will be ignored when Kafka Node Pools are used
+    storage:
+      type: ephemeral
+  # The ZooKeeper section is required by the Kafka CRD schema while the UseKRaft feature gate is in alpha phase.
+  # But it will be ignored when running in KRaft mode
+  zookeeper:
+    replicas: 3
+    storage:
+      type: ephemeral
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+

--- a/kubernetes/strimzi-kafka/kafka-topics.yaml
+++ b/kubernetes/strimzi-kafka/kafka-topics.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: test1
+  labels:
+    strimzi.io/cluster: chaosmania-kafka-cluster
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 604800000
+    segment.bytes: 1073741824
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: inventory-video-encoding
+  labels:
+    strimzi.io/cluster: chaosmania-kafka-cluster
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 604800000
+    segment.bytes: 1073741824
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: upload-video-encoding
+  labels:
+    strimzi.io/cluster: chaosmania-kafka-cluster
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 604800000
+    segment.bytes: 1073741824

--- a/pkg/actions/kafka_consumer_service.go
+++ b/pkg/actions/kafka_consumer_service.go
@@ -229,7 +229,7 @@ func (consumer *KafkaConsumerService) handleMessage(ctx context.Context, message
 	span.SetAttributes(semconv.MessagingSystem("kafka"))
 
 	// https://opentelemetry.io/docs/specs/semconv/messaging/kafka/#:~:text=For%20Apache%20Kafka%20producers
-	span.SetAttributes(semconv.ServiceName(consumer.config.Brokers[0])) // TODO: handle array?
+	span.SetAttributes(semconv.ServiceName(consumer.config.TracingServiceName))
 
 	//setConsumeCheckpoint(true, consumer.config.Group, message)
 

--- a/pkg/actions/kafka_consumer_service.go
+++ b/pkg/actions/kafka_consumer_service.go
@@ -4,17 +4,16 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
-	oteltrace "go.opentelemetry.io/otel/trace"
 	"sync"
 	"time"
 
 	"github.com/Causely/chaosmania/pkg"
 	"github.com/Causely/chaosmania/pkg/logger"
 	"github.com/IBM/sarama"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	saramatrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/IBM/sarama.v1"
 	"gopkg.in/DataDog/dd-trace-go.v1/datastreams"
@@ -221,7 +220,6 @@ func (consumer *KafkaConsumerService) handleMessage(ctx context.Context, message
 	consumeTracer := otel.GetTracerProvider().Tracer("kafka-consumer")
 	ctx, span := consumeTracer.Start(ctx, "Consume Topic"+consumer.config.Topic, oteltrace.WithSpanKind(oteltrace.SpanKindConsumer))
 	defer span.End()
-	span.SetAttributes(attribute.String("span.Kind", "consumer"))
 	span.SetAttributes(semconv.MessagingKafkaDestinationPartition(int(message.Partition)))
 	span.SetAttributes(semconv.MessagingKafkaMessageOffset(int(message.Offset)))
 	span.SetAttributes(semconv.MessagingDestinationName(consumer.config.Topic))

--- a/pkg/actions/kafka_producer_service.go
+++ b/pkg/actions/kafka_producer_service.go
@@ -3,16 +3,15 @@ package actions
 import (
 	"context"
 	"crypto/tls"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
-	oteltrace "go.opentelemetry.io/otel/trace"
 	"time"
 
 	"github.com/Causely/chaosmania/pkg"
 	"github.com/Causely/chaosmania/pkg/logger"
 	"github.com/IBM/sarama"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	saramatrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/IBM/sarama.v1"
 	"gopkg.in/DataDog/dd-trace-go.v1/datastreams"
@@ -116,7 +115,6 @@ func (s *KafkaProducerService) Produce(ctx context.Context, topic string, msg st
 
 	m := &sarama.ProducerMessage{Topic: topic, Value: sarama.StringEncoder(msg)}
 
-	span.SetAttributes(attribute.String("span.Kind", "producer"))
 	span.SetAttributes(semconv.MessagingKafkaDestinationPartition(int(m.Partition)))
 	span.SetAttributes(semconv.MessagingKafkaMessageOffset(int(m.Offset)))
 	span.SetAttributes(semconv.MessagingDestinationName(topic))
@@ -174,11 +172,9 @@ func NewKafkaProducerService(name ServiceName, config map[string]any) (Service, 
 		return nil, err
 	}
 
-	//if pkg.IsDatadogEnabled() {
 	producer = saramatrace.WrapSyncProducer(c,
 		producer,
 		saramatrace.WithServiceName(cfg.TracingServiceName))
-	//}
 
 	kafkaService.producer = producer
 

--- a/pkg/actions/kafka_producer_service.go
+++ b/pkg/actions/kafka_producer_service.go
@@ -124,7 +124,7 @@ func (s *KafkaProducerService) Produce(ctx context.Context, topic string, msg st
 	span.SetAttributes(semconv.ServiceName(s.config.TracingServiceName))
 
 	// https://opentelemetry.io/docs/specs/semconv/messaging/kafka/#:~:text=For%20Apache%20Kafka%20producers
-	span.SetAttributes(semconv.PeerService(s.config.Brokers[0])) // TODO: handle array?
+	span.SetAttributes(semconv.PeerService(s.config.TracingServiceName))
 
 	setProduceCheckpoint(m)
 

--- a/pkg/actions/kafka_producer_service.go
+++ b/pkg/actions/kafka_producer_service.go
@@ -3,6 +3,11 @@ package actions
 import (
 	"context"
 	"crypto/tls"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"time"
 
 	"github.com/Causely/chaosmania/pkg"
@@ -42,6 +47,24 @@ func (s *KafkaProducerService) Type() ServiceType {
 	return "kafka-producer"
 }
 
+// NewOTelInterceptor processes span for intercepted messages and add some
+// headers with the span data.
+//func NewOTelInterceptor(brokers []string) *OTelInterceptor {
+//	oi := OTelInterceptor{}
+//	oi.tracer = sdktrace.NewTracerProvider().Tracer("chaosmania/kafka-producer")
+//
+//	// These are based on the spec, which was reachable as of 2020-05-15
+//	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md
+//	oi.fixedAttrs = []attribute.KeyValue{
+//		attribute.String(string(semconv.MessagingDestinationNameKey), "topic"),
+//		attribute.String("span.otel.kind", "PRODUCER"),
+//		attribute.String("messaging.system", "kafka"),
+//		attribute.String("net.transport", "IP.TCP"),
+//		attribute.String("messaging.url", strings.Join(brokers, ",")),
+//	}
+//	return &oi
+//}
+
 func getProducerMsgSize(msg *sarama.ProducerMessage) (size int64) {
 	for _, header := range msg.Headers {
 		size += int64(len(header.Key) + len(header.Value))
@@ -55,7 +78,7 @@ func getProducerMsgSize(msg *sarama.ProducerMessage) (size int64) {
 	return size
 }
 
-func (s *KafkaProducerService) Produce(ctx context.Context, topic string, msg string) error {
+func (s *KafkaProducerService) ddProduce(ctx context.Context, topic string, msg string) error {
 	span, _ := tracer.SpanFromContext(ctx)
 
 	m := &sarama.ProducerMessage{Topic: topic, Value: sarama.StringEncoder(msg)}
@@ -72,11 +95,45 @@ func (s *KafkaProducerService) Produce(ctx context.Context, topic string, msg st
 	partition, offset, err := s.producer.SendMessage(m)
 	if err != nil {
 		logger.FromContext(ctx).Warn("failed to send message", zap.Error(err))
+		//span.Finish(tracer.WithError(err))
 		return err
 	}
 
+	tracer.TrackKafkaProduceOffset(topic, partition, offset)
+
+	return nil
+}
+
+func (s *KafkaProducerService) Produce(ctx context.Context, topic string, msg string) error {
 	if pkg.IsDatadogEnabled() {
-		tracer.TrackKafkaProduceOffset(topic, partition, offset)
+		return s.ddProduce(ctx, topic, msg)
+	}
+
+	prodTracer := otel.GetTracerProvider().Tracer("kafka-producer")
+
+	ctx, span := prodTracer.Start(ctx, "Produce Message", oteltrace.WithSpanKind(oteltrace.SpanKindProducer))
+	defer span.End()
+
+	m := &sarama.ProducerMessage{Topic: topic, Value: sarama.StringEncoder(msg)}
+
+	span.SetAttributes(attribute.String("span.Kind", "producer"))
+	span.SetAttributes(semconv.MessagingKafkaDestinationPartition(int(m.Partition)))
+	span.SetAttributes(semconv.MessagingKafkaMessageOffset(int(m.Offset)))
+	span.SetAttributes(semconv.MessagingDestinationName(topic))
+	span.SetAttributes(semconv.MessagingSystem("kafka"))
+	span.SetAttributes(semconv.ServiceName(s.config.TracingServiceName))
+
+	// https://opentelemetry.io/docs/specs/semconv/messaging/kafka/#:~:text=For%20Apache%20Kafka%20producers
+	span.SetAttributes(semconv.PeerService(s.config.Brokers[0])) // TODO: handle array?
+
+	setProduceCheckpoint(m)
+
+	_, _, err := s.producer.SendMessage(m)
+	if err != nil {
+		logger.FromContext(ctx).Warn("failed to send message", zap.Error(err))
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
 	}
 
 	return nil
@@ -117,11 +174,11 @@ func NewKafkaProducerService(name ServiceName, config map[string]any) (Service, 
 		return nil, err
 	}
 
-	if pkg.IsDatadogEnabled() {
-		producer = saramatrace.WrapSyncProducer(c,
-			producer,
-			saramatrace.WithServiceName(cfg.TracingServiceName))
-	}
+	//if pkg.IsDatadogEnabled() {
+	producer = saramatrace.WrapSyncProducer(c,
+		producer,
+		saramatrace.WithServiceName(cfg.TracingServiceName))
+	//}
 
 	kafkaService.producer = producer
 

--- a/scripts/create_kafka_cluster.sh
+++ b/scripts/create_kafka_cluster.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+NS=chaosmania
+
+# https://github.com/strimzi/strimzi-kafka-operator/tree/main/helm-charts/helm3/strimzi-kafka-operator
+helm repo add strimzi https://strimzi.io/charts/
+helm upgrade --install strimzi-kafka-operator strimzi/strimzi-kafka-operator -n ${NS} --set featureGates=+UseKRaft
+helm upgrade --install kafka-exporter prometheus-community/prometheus-kafka-exporter --namespace=${NS} --values ../kubernetes/strimzi-kafka/exporters/prometheus_kafka_values.yaml
+
+kubectl apply -n ${NS} -f ../kubernetes/strimzi-kafka/kafka-cluster-descriptor.yaml
+kubectl apply -n ${NS} -f ../kubernetes/strimzi-kafka/kafka-topics.yaml

--- a/scripts/delete_kafka_cluster.sh
+++ b/scripts/delete_kafka_cluster.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+NS=chaosmania
+
+helm delete -n ${NS} strimzi-kafka-operator
+helm delete -n ${NS} kafka-exporter
+
+kubectl delete -n ${NS} -f ../kubernetes/strimzi-kafka/kafka-cluster-descriptor.yaml
+kubectl delete -n ${NS} -f ../kubernetes/strimzi-kafka/kafka-topics.yaml

--- a/update_video_clients.sh
+++ b/update_video_clients.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
+NS=chaosmania
+IMAGE_TAG=latest
+CHAOS_HOST=frontend
+
 python plans/make_video_plans.py upload create > ./plans/video_upload.yaml 
 python plans/make_video_plans.py show-recommendations create > ./plans/video_show_recommendations.yaml 
 python plans/make_video_plans.py show-video create > ./plans/video_show_video.yaml 
 
-helm delete --namespace platform client-show-video
-helm delete --namespace platform client-show-recommendations
-helm delete --namespace platform client-upload
+helm delete --namespace ${NS} client-show-video
+helm delete --namespace ${NS} client-show-recommendations
+helm delete --namespace ${NS} client-upload
 
-helm upgrade --install --create-namespace --namespace platform client-show-video ./helm/client  --set chaos.plan="/plans/video_show_video.yaml" --set chaos.host=frontend --set image.tag=steffen
-helm upgrade --install --create-namespace --namespace platform client-show-recommendations ./helm/client  --set chaos.plan="/plans/video_show_recommendations.yaml" --set chaos.host=frontend --set image.tag=steffen
-helm upgrade --install --create-namespace --namespace platform client-upload ./helm/client  --set chaos.plan="/plans/video_upload.yaml" --set chaos.host=frontend --set image.tag=steffen
+helm upgrade --install --create-namespace --namespace ${NS} client-show-video ./helm/client  --set chaos.plan="/plans/video_show_video.yaml" --set chaos.host=${CHAOS_HOST} --set image.tag=${IMAGE_TAG}
+helm upgrade --install --create-namespace --namespace ${NS} client-show-recommendations ./helm/client  --set chaos.plan="/plans/video_show_recommendations.yaml" --set chaos.host=${CHAOS_HOST} --set image.tag=${IMAGE_TAG}
+helm upgrade --install --create-namespace --namespace ${NS} client-upload ./helm/client  --set chaos.plan="/plans/video_upload.yaml" --set chaos.host=${CHAOS_HOST} --set image.tag=${IMAGE_TAG}


### PR DESCRIPTION
# Description

- Added instrumentation tracing with OTEL for non-datadog kafka use-cases
- Added Strimzi/Kafka yaml configuration files for local Kafka cluster setup
- Added documentation readme files
- Added shell scripts to manage create/delete of local kafka cluster resources

JIRA: [DEV-834]

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation has been updated


[DEV-834]: https://causely.atlassian.net/browse/DEV-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ