### PR TITLE
Add scenarios

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ARG TARGETARCH
 
 COPY ./out/chaosmania-${TARGETOS}-${TARGETARCH} /bin/chaosmania
 COPY ./plans /plans
+COPY ./scenarios /scenarios
 
 # Create a user group 'chaosmania'
 RUN addgroup --system chaosmania -gid 3000

--- a/helm/client/scenarios
+++ b/helm/client/scenarios
@@ -1,0 +1,1 @@
+../../scenarios

--- a/helm/client/templates/configmap.yaml
+++ b/helm/client/templates/configmap.yaml
@@ -1,9 +1,19 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{include "client.fullname" .}}-chaosconfig
+  name: {{include "client.fullname" .}}-plans
 data:
-{{- range $path, $_ :=  .Files.Glob .Values.chaos.files }}
+{{- range $path, $_ :=  .Files.Glob .Values.chaos.plans }}
 {{ $path | trimPrefix "plans/"  | indent 2 }}: |-
+{{ $.Files.Get $path | indent 4 }}
+{{ end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{include "client.fullname" .}}-scenarios
+data:
+{{- range $path, $_ :=  .Files.Glob .Values.chaos.scenarios }}
+{{ $path | trimPrefix "scenarios/" | replace "/" "-" | indent 2 }}: |-
 {{ $.Files.Get $path | indent 4 }}
 {{ end }}

--- a/helm/client/templates/job.yaml
+++ b/helm/client/templates/job.yaml
@@ -21,10 +21,15 @@ spec:
           - "--port"
           - {{.Values.chaos.port| quote}}
         volumeMounts:
-          - name: chaos-volume
+          - name: chaos-plans
             mountPath: /plans
+          - name: chaos-scenarios
+            mountPath: /scenarios
       volumes:
-        - name: chaos-volume
+        - name: chaos-plans
           configMap:
-            name: {{include "client.fullname" .}}-chaosconfig
+            name: {{include "client.fullname" .}}-plans
+        - name: chaos-scenarios
+          configMap:
+            name: {{include "client.fullname" .}}-scenarios 
       restartPolicy: Never

--- a/helm/client/values.yaml
+++ b/helm/client/values.yaml
@@ -4,9 +4,9 @@ image:
   tag: "latest"
 
 resources:
-  limits:
-     cpu: 100m
-     memory: 128Mi
+  # limits:
+  #    cpu: 100m
+  #    memory: 128Mi
   requests:
     cpu: 10m
     memory: 64Mi
@@ -15,4 +15,5 @@ chaos:
   plan: "/plans/boutique.yaml"
   host: "single"
   port: "8080"
-  files: "plans/*.yaml"
+  plans: "plans/*.yaml"
+  scenarios: "scenarios/**.yaml"

--- a/helm/single/templates/_helpers.tpl
+++ b/helm/single/templates/_helpers.tpl
@@ -114,17 +114,7 @@ Create the name of the service account to use
     httpGet:
       path: /health
       port: http
-  securityContext:
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
-    allowPrivilegeEscalation: false
-    privileged: false
-    readOnlyRootFilesystem: true
-    capabilities:
-      drop:
-      - all
-      add: ['NET_BIND_SERVICE']
+  securityContext: {{- toYaml .Values.securityContext | nindent 4}}
   resources: {{- toYaml .Values.resources | nindent 4}}
   env:
     {{- include "otel.env" . | nindent 4 }}

--- a/helm/single/templates/deployment.yaml
+++ b/helm/single/templates/deployment.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       {{- include "single.selectorLabels" . | nindent 6}}
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:

--- a/helm/single/values.yaml
+++ b/helm/single/values.yaml
@@ -11,6 +11,20 @@ resources:
     cpu: 10m
     memory: 64Mi
 
+replicaCount: 1
+
+securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+    - all
+    add: ['NET_BIND_SERVICE']
+
 otlp:
   endpoint: "" # http://tempo.monitoring:4318
   insecure: true

--- a/pkg/actions/create_file_action.go
+++ b/pkg/actions/create_file_action.go
@@ -1,0 +1,37 @@
+package actions
+
+import (
+	"context"
+	"os"
+
+	"github.com/Causely/chaosmania/pkg"
+	"github.com/Causely/chaosmania/pkg/logger"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+type CreateFile struct{}
+
+type CreateFileConfig struct {
+	Directory string `json:"directory"`
+	Size      int    `json:"size"`
+}
+
+func (a *CreateFile) Execute(ctx context.Context, cfg map[string]any) error {
+	config, err := pkg.ParseConfig[CreateFileConfig](cfg)
+	if err != nil {
+		logger.FromContext(ctx).Warn("failed to parse config", zap.Error(err))
+		return err
+	}
+
+	filename := config.Directory + "/" + uuid.NewString()
+	return os.WriteFile(filename, make([]byte, config.Size), 0644)
+}
+
+func (a *CreateFile) ParseConfig(data map[string]any) (any, error) {
+	return pkg.ParseConfig[CreateFileConfig](data)
+}
+
+func init() {
+	ACTIONS["CreateFile"] = &CreateFile{}
+}

--- a/pkg/actions/panic.go
+++ b/pkg/actions/panic.go
@@ -1,0 +1,42 @@
+package actions
+
+import (
+	"context"
+	"math/rand"
+	"os"
+
+	"github.com/Causely/chaosmania/pkg"
+	"github.com/Causely/chaosmania/pkg/logger"
+	"go.uber.org/zap"
+)
+
+type Panic struct {
+}
+
+type PanicConfig struct {
+	Probability float64 `json:"probability"`
+}
+
+func (a *Panic) Execute(ctx context.Context, cfg map[string]any) error {
+	config, err := pkg.ParseConfig[PanicConfig](cfg)
+	if err != nil {
+		logger.FromContext(ctx).Warn("failed to parse config", zap.Error(err))
+		return err
+	}
+
+	if config.Probability > 0 {
+		if rand.Float64() < config.Probability {
+			os.Exit(1)
+		}
+	}
+
+	return nil
+}
+
+func (a *Panic) ParseConfig(data map[string]any) (any, error) {
+	return pkg.ParseConfig[PanicConfig](data)
+}
+
+func init() {
+	ACTIONS["Panic"] = &Panic{}
+}

--- a/scenarios/container-cpu-congestion/plan.yaml
+++ b/scenarios/container-cpu-congestion/plan.yaml
@@ -1,0 +1,16 @@
+---
+phases:
+  - name: Phase1
+    repeat: 5000
+
+    client:
+      workers:
+        - instances: 10
+          duration: 1h
+          delay: 500ms
+
+    workload:
+      actions:
+        - name: Burn
+          config:
+            duration: 500ms

--- a/scenarios/container-cpu-congestion/run.sh
+++ b/scenarios/container-cpu-congestion/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+IMAGE_REPO=quay.io/causely/chaosmania
+IMAGE_TAG=latest
+NAMESPACE=container-cpu-congestion
+
+helm upgrade --install --create-namespace --namespace $NAMESPACE \
+    --set image.tag=$IMAGE_TAG \
+    --set resources.limits.cpu="500m"\
+    --set replicaCount=3 \
+    single $SCRIPT_DIR/../../helm/single 
+
+helm delete --namespace $NAMESPACE client
+helm upgrade --install --create-namespace --namespace $NAMESPACE \
+    --set image.tag=$IMAGE_TAG \
+    --set chaos.plan=/scenarios/container-cpu-congestion-plan.yaml \
+    client $SCRIPT_DIR/../../helm/client
+

--- a/scenarios/ephemeral-storage-eviction/plan.yaml
+++ b/scenarios/ephemeral-storage-eviction/plan.yaml
@@ -1,0 +1,17 @@
+---
+phases:
+  - name: Phase1
+    repeat: 5000
+
+    client:
+      workers:
+        - instances: 1
+          duration: 1h
+          delay: 1s
+
+    workload:
+      actions:
+        - name: CreateFile
+          config:
+            directory: /tmp
+            size: 200000 # 200Kb

--- a/scenarios/ephemeral-storage-eviction/run.sh
+++ b/scenarios/ephemeral-storage-eviction/run.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+IMAGE_REPO=quay.io/causely/chaosmania
+IMAGE_TAG=latest
+NAMESPACE=ephemeral-storage-eviction
+
+helm upgrade --install --create-namespace --namespace $NAMESPACE \
+    --set image.tag=$IMAGE_TAG \
+    --set resources.limits.ephemeral-storage=256Mi \
+    --set securityContext.readOnlyRootFilesystem=false \
+    --set replicaCount=3 \
+    single $SCRIPT_DIR/../../helm/single 
+
+helm delete --namespace $NAMESPACE client
+helm upgrade --install --create-namespace --namespace $NAMESPACE \
+    --set image.tag=$IMAGE_TAG \
+    --set chaos.plan=/scenarios/ephemeral-storage-eviction-plan.yaml \
+    client $SCRIPT_DIR/../../helm/client
+

--- a/scenarios/periodical-crash/plan.yaml
+++ b/scenarios/periodical-crash/plan.yaml
@@ -1,0 +1,16 @@
+---
+phases:
+  - name: Phase1
+    repeat: 5000
+
+    client:
+      workers:
+        - instances: 1
+          duration: 1h
+          delay: 1s
+
+    workload:
+      actions:
+        - name: Panic 
+          config:
+            probability: 0.001

--- a/scenarios/periodical-crash/run.sh
+++ b/scenarios/periodical-crash/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+IMAGE_REPO=quay.io/causely/chaosmania
+IMAGE_TAG=latest
+NAMESPACE=periodical-crash
+
+helm upgrade --install --create-namespace --namespace $NAMESPACE \
+    --set image.tag=$IMAGE_TAG \
+    --set resources.limits.memory=256Mi \
+    --set replicaCount=3 \
+    single $SCRIPT_DIR/../../helm/single 
+
+helm delete --namespace $NAMESPACE client
+helm upgrade --install --create-namespace --namespace $NAMESPACE \
+    --set image.tag=$IMAGE_TAG \
+    --set chaos.plan=/scenarios/periodical-crash-plan.yaml \
+    client $SCRIPT_DIR/../../helm/client
+

--- a/scenarios/periodical-oom/plan.yaml
+++ b/scenarios/periodical-oom/plan.yaml
@@ -1,0 +1,18 @@
+---
+phases:
+  - name: Phase1
+    repeat: 5000
+
+    client:
+      workers:
+        - instances: 3
+          duration: 1h
+          delay: 100ms
+
+    workload:
+      actions:
+        - name: AllocateMemory
+          config:
+            sizeBytes: 25000 # 25Kb
+            numAllocations: 1
+            leak: true

--- a/scenarios/periodical-oom/run.sh
+++ b/scenarios/periodical-oom/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+IMAGE_REPO=quay.io/causely/chaosmania
+IMAGE_TAG=latest
+NAMESPACE=periodical-oom
+
+helm upgrade --install --create-namespace --namespace $NAMESPACE \
+    --set image.tag=$IMAGE_TAG \
+    --set resources.limits.memory=256Mi \
+    --set replicaCount=3 \
+    single $SCRIPT_DIR/../../helm/single 
+
+helm delete --namespace $NAMESPACE client
+helm upgrade --install --create-namespace --namespace $NAMESPACE \
+    --set image.tag=$IMAGE_TAG \
+    --set chaos.plan=/scenarios/periodical-oom-plan.yaml \
+    client $SCRIPT_DIR/../../helm/client
+

--- a/scenarios/run_all.sh
+++ b/scenarios/run_all.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+$SCRIPT_DIR/ephemeral-storage-eviction/run.sh
+$SCRIPT_DIR/container-cpu-congestion/run.sh
+$SCRIPT_DIR/periodical-crash/run.sh
+$SCRIPT_DIR/periodical-oom/run.sh


### PR DESCRIPTION
Add several scenarios:

- Container CPU Congestion
- Ephemeral Storage Eviction
- Periodical Crash
- Periodical OOM

They can be installed in a cluster by running `./scenarios/run_all.sh` or only the individual scenario with `./run.sh` from each scenarios directory.