### PR TITLE
remove redis workaround for server address

### DIFF
--- a/helm/boutique/templates/_helpers.tpl
+++ b/helm/boutique/templates/_helpers.tpl
@@ -18,6 +18,7 @@
 {{- define "common.labels" }}
 app.kubernetes.io/instance: {{ . }}
 app.kubernetes.io/name: {{ . }}
+app.kubernetes.io/part-of: boutique
 tags.datadoghq.com/env: test
 tags.datadoghq.com/service: {{ . }}
 tags.datadoghq.com/version: "1"
@@ -111,7 +112,6 @@ tags.datadoghq.com/version: "1"
     capabilities:
       drop:
       - all
-      add: ['NET_BIND_SERVICE']
   resources: {{- toYaml .Values.resources | nindent 4}}
   env:
     {{- include "otel.env" . | nindent 4 }}

--- a/helm/single/templates/_helpers.tpl
+++ b/helm/single/templates/_helpers.tpl
@@ -109,11 +109,11 @@ Create the name of the service account to use
       port: http
   securityContext: {{- toYaml .Values.securityContext | nindent 4}}
   resources: {{- toYaml .Values.resources | nindent 4}}
+  {{ if .Values.persistence.enabled }}
   volumeMounts:
-    {{ if .Values.persistence.enabled }}
     - mountPath: "/data"
       name: repository
-    {{ end }}
+  {{ end }}
   env:
     {{- include "otel.env" . | nindent 4 }}
     {{- include "common.env" . | nindent 4 }}

--- a/helm/single/templates/deployment.yaml
+++ b/helm/single/templates/deployment.yaml
@@ -22,8 +22,6 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}
         app.kubernetes.io/part-of: {{ .Values.business_application }}
     spec:
-      securityContext:
-        fsGroup: 2000
       {{- if .Values.nodeName }}
       nodeSelector:
         kubernetes.io/hostname: {{ .Values.nodeName }}
@@ -34,9 +32,14 @@ spec:
             value: "{{ .Values.ndots }}"
       containers:
       {{- include "chaosmania.container" . | nindent 8}}
+      {{ if .Values.persistence.enabled }}
+      securityContext:
+        fsGroup: 2000
       volumes:
-        {{ if .Values.persistence.enabled }}
         - name: repository
           persistentVolumeClaim:
-              claimName: data 
-        {{ end }}
+            claimName: data
+            {{ if .Values.persistence.storageClass }}
+            storageClassName: {{ .Values.persistence.storageClass }}
+            {{ end }}
+      {{ end }}

--- a/helm/single/values.yaml
+++ b/helm/single/values.yaml
@@ -7,10 +7,12 @@ ndots: 5
 
 persistence:
   enabled: false
-  storageClass: ""
   size: 11Gi
+#  storageClass:
 
-nodeName: 
+business_application: "single"
+
+#nodeName:
 
 resources:
   # limits:
@@ -32,7 +34,6 @@ securityContext:
   capabilities:
     drop:
     - all
-    add: ['NET_BIND_SERVICE']
 
 otlp:
   endpoint: "" # http://tempo.monitoring:4318

--- a/helm/video/templates/_helpers.tpl
+++ b/helm/video/templates/_helpers.tpl
@@ -18,6 +18,7 @@
 {{- define "common.labels" }}
 app.kubernetes.io/instance: {{ . }}
 app.kubernetes.io/name: {{ . }}
+app.kubernetes.io/part-of: video
 tags.datadoghq.com/env: test
 tags.datadoghq.com/service: {{ . }}
 tags.datadoghq.com/version: "1"
@@ -124,7 +125,6 @@ scrape-prometheus: "true"
     capabilities:
       drop:
       - all
-      add: ['NET_BIND_SERVICE']
   resources: {{- toYaml .Values.resources | nindent 4}}
   env:
     {{- include "otel.env" . | nindent 4 }}

--- a/pkg/actions/mongodb.go
+++ b/pkg/actions/mongodb.go
@@ -172,14 +172,13 @@ func (mongodb *MongoDBQuery) Execute(ctx context.Context, cfg map[string]any) er
 
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
-	for {
-		client, err := mongo.Connect(ctx, mongodb.clientOpts)
-		if err != nil {
-			logger.FromContext(ctx).Error("failed to connect to mongodb", zap.Error(err))
-		}
-		mongodb.mongoClient = client
-		break
+
+	client, err := mongo.Connect(ctx, mongodb.clientOpts)
+	if err != nil {
+		logger.FromContext(ctx).Error("failed to connect to mongodb", zap.Error(err))
+		return err
 	}
+	mongodb.mongoClient = client
 
 	dbname := "admin"
 	if config.DBname != "" {

--- a/pkg/actions/redis_action.go
+++ b/pkg/actions/redis_action.go
@@ -10,7 +10,6 @@ import (
 	redis8 "github.com/go-redis/redis/v8"
 	"github.com/redis/go-redis/extra/redisotel/v9"
 	redis9 "github.com/redis/go-redis/v9"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.uber.org/zap"
 	redistrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis.v8"
 )
@@ -64,11 +63,7 @@ func (redis *RedisCommand) Execute(ctx context.Context, cfg map[string]any) erro
 		if err != nil {
 			logger.FromContext(ctx).Error("failed to enable redis opentelemetry metrics", zap.Error(err))
 		}
-		err = redisotel.InstrumentTracing(rdb,
-			redisotel.WithAttributes(
-				semconv.ServerAddress("redis"),
-				semconv.ServerPort(6379),
-			))
+		err = redisotel.InstrumentTracing(rdb)
 		if err != nil {
 			logger.FromContext(ctx).Error("failed to enable redis opentelemetry tracing", zap.Error(err))
 		}

--- a/pkg/actions/script_action.go
+++ b/pkg/actions/script_action.go
@@ -86,7 +86,7 @@ func (sc *ScriptContext) Sleep(duration string) error {
 		return err
 	}
 
-	cfg.Duration = pkg.Duration{d}
+	cfg.Duration = pkg.Duration{Duration: d}
 
 	c, err := pkg.ConfigToMap(&cfg)
 	if err != nil {
@@ -125,7 +125,7 @@ func (sc *ScriptContext) Burn(duration string) error {
 		return err
 	}
 
-	cfg.Duration = pkg.Duration{d}
+	cfg.Duration = pkg.Duration{Duration: d}
 
 	c, err := pkg.ConfigToMap(&cfg)
 	if err != nil {
@@ -179,7 +179,10 @@ func (s *Script) Execute(ctx context.Context, cfg map[string]any) error {
 	}
 
 	vm.SetFieldNameMapper(goja.UncapFieldNameMapper())
-	vm.Set("ctx", scriptContext)
+	err = vm.Set("ctx", scriptContext)
+	if err != nil {
+		return err
+	}
 
 	run, ok := goja.AssertFunction(vm.Get("run"))
 	if !ok {


### PR DESCRIPTION
# Description

remove redis workaround for server address after go-redis has been upgraded to 9.5.2
https://github.com/Causely/chaosmania/pull/135

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
