### PR TITLE
increased memory allocation in periodical oom scenario

### DIFF
--- a/scenarios/periodical-oom/plan.yaml
+++ b/scenarios/periodical-oom/plan.yaml
@@ -13,6 +13,6 @@ phases:
       actions:
         - name: AllocateMemory
           config:
-            sizeBytes: 25000 # 25Kb
+            sizeBytes: 125000 # 125Kb
             numAllocations: 1
             leak: true


### PR DESCRIPTION
# Description

periodical-oom scenario is using 25 kb memory leak , which is too slow for autotest ( memory kill occurs aprox every 25 min).changed  oom scenario AllocateMemory sizeBytes from 25 kb to 125 kb

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

