### PR TITLE
[DEV-3162] Add some knobs to control runtime of scenarios for chaosmania-test

### DIFF
--- a/cmd/chaosmania/client.go
+++ b/cmd/chaosmania/client.go
@@ -128,6 +128,14 @@ loop:
 	for {
 		select {
 		case <-ctx.Done():
+			switch ctx.Err() {
+			case context.Canceled:
+				logger.Debug("Worker stopping due to command completion")
+			case context.DeadlineExceeded:
+				logger.Debug("Worker stopping due to timeout")
+			default:
+				logger.Debug("Worker stopping due to context error", zap.Error(ctx.Err()))
+			}
 			break loop
 		case <-time.After(delay):
 			start := time.Now()
@@ -155,6 +163,18 @@ loop:
 			took := time.Since(start)
 
 			if err != nil {
+				// Check if the error is due to context cancellation
+				if ctx.Err() != nil {
+					switch ctx.Err() {
+					case context.Canceled:
+						logger.Debug("Request cancelled due to command completion")
+					case context.DeadlineExceeded:
+						logger.Debug("Request cancelled due to timeout")
+					default:
+						logger.Debug("Request cancelled due to context error", zap.Error(ctx.Err()))
+					}
+					break loop
+				}
 				atomic.AddUint64(&stats.counters.Errors, 1)
 				continue
 			}
@@ -162,6 +182,7 @@ loop:
 			if resp.StatusCode == 400 {
 				s, err := io.ReadAll(resp.Body)
 				if err != nil {
+					resp.Body.Close()
 					continue
 				}
 
@@ -186,7 +207,7 @@ loop:
 	}
 }
 
-func executePhase(logger *zap.Logger, phase actions.Phase, raw map[string]any, host string, port int64, header map[string]string) error {
+func executePhase(logger *zap.Logger, phase actions.Phase, raw map[string]any, host string, port int64, header map[string]string, ctx context.Context) error {
 	logger.Info("")
 	logger.Info(fmt.Sprintf("Starting phase: %s", phase.Name))
 
@@ -210,8 +231,8 @@ func executePhase(logger *zap.Logger, phase actions.Phase, raw map[string]any, h
 		var wg sync.WaitGroup
 		wg.Add(int(w.Instances))
 
-		ctx := context.Background()
-		ctx, cancel := context.WithTimeout(ctx, w.Duration)
+		// Create a child context with timeout that will be cancelled when parent is cancelled
+		workerCtx, cancel := context.WithTimeout(ctx, w.Duration)
 		defer cancel()
 
 		payloadBytes, err := json.Marshal(raw["workload"])
@@ -222,7 +243,7 @@ func executePhase(logger *zap.Logger, phase actions.Phase, raw map[string]any, h
 		for i := 0; i < int(w.Instances); i++ {
 			go func(stats *statistics) {
 				defer wg.Done()
-				runWorker(logger, stats, w.Timeout, ctx, w.Delay, host, port, payloadBytes, header)
+				runWorker(logger, stats, w.Timeout, workerCtx, w.Delay, host, port, payloadBytes, header)
 			}(&stats)
 		}
 
@@ -233,6 +254,7 @@ func executePhase(logger *zap.Logger, phase actions.Phase, raw map[string]any, h
 			var last statisticCounters
 			interval := 10
 			t := time.NewTicker(time.Duration(interval) * time.Second)
+			defer t.Stop()
 
 			for {
 				select {
@@ -257,7 +279,7 @@ func executePhase(logger *zap.Logger, phase actions.Phase, raw map[string]any, h
 
 					last = current
 					logger.Info(fmt.Sprintf("%.1f req/s, avg latency %v, %v errors, %v ok", float64(requests)/float64(interval), latency, errors, ok))
-				case <-ctx.Done():
+				case <-workerCtx.Done():
 					return
 				}
 			}
@@ -266,18 +288,8 @@ func executePhase(logger *zap.Logger, phase actions.Phase, raw map[string]any, h
 		wg.Wait()
 	}
 
-	// Teardown
-	if t, ok := raw["teardown"]; ok {
-		err := sendRequest(logger, t.(map[string]any), host, port, header)
-		if err != nil {
-			return err
-		}
-	}
-
 	var a time.Duration
-
 	successfulRequests := stats.counters.Requests - stats.counters.Errors
-
 	if successfulRequests > 0 {
 		a = time.Duration(int64(stats.counters.DurationMicroseconds/successfulRequests)) * time.Microsecond
 	}
@@ -294,7 +306,17 @@ func executePhase(logger *zap.Logger, phase actions.Phase, raw map[string]any, h
 		logger.Info(fmt.Sprintf("%v: %v", code, count))
 	}
 
-	return nil
+	// Always run teardown, even if context is cancelled
+	if t, ok := raw["teardown"]; ok {
+		logger.Info("Running teardown...")
+		err := sendRequest(logger, t.(map[string]any), host, port, header)
+		if err != nil {
+			logger.Warn("Teardown failed", zap.Error(err))
+			// Don't return the error since we want to ensure the context cancellation propagates
+		}
+	}
+
+	return ctx.Err()
 }
 
 func command_client(logger *zap.Logger, ctx *cli.Context) error {
@@ -302,6 +324,13 @@ func command_client(logger *zap.Logger, ctx *cli.Context) error {
 	host := ctx.String("host")
 	port := ctx.Int64("port")
 	header := ctx.StringSlice("header")
+
+	// Create a root context that will be cancelled when the command completes
+	rootCtx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		logger.Info("Command completed, initiating graceful shutdown...")
+		cancel()
+	}()
 
 	headers := make(map[string]string)
 	for _, h := range header {
@@ -334,7 +363,7 @@ func command_client(logger *zap.Logger, ctx *cli.Context) error {
 
 	for i, phase := range plan.Phases {
 		for j := 0; j < int(phase.Repeat); j++ {
-			err := executePhase(logger, phase, raw["phases"].([]any)[i].(map[string]any), host, port, headers)
+			err := executePhase(logger, phase, raw["phases"].([]any)[i].(map[string]any), host, port, headers, rootCtx)
 			if err != nil {
 				return err
 			}

--- a/cmd/chaosmania/client.go
+++ b/cmd/chaosmania/client.go
@@ -22,10 +22,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const (
-	MaxRepeatsPerPhase = 500
-)
-
 func loadPlan(logger *zap.Logger, path string) (actions.Plan, map[string]any, error) {
 	var plan actions.Plan
 	var raw map[string]any

--- a/cmd/chaosmania/main.go
+++ b/cmd/chaosmania/main.go
@@ -52,9 +52,15 @@ func main() {
 					Required: false,
 				},
 				&cli.StringFlag{
-					Name:     "duration",
-					Usage:    "Total duration for the test run (e.g. '1h', '30m', '2h30m')",
+					Name:     "total-duration",
+					Usage:    "Total duration for the test run (e.g. '1h', '30m', '2h30m').  Plans with multiple phases will be scaled to fit this duration.",
 					Required: false,
+				},
+				&cli.IntFlag{
+					Name:     "max-repeats",
+					Usage:    "Maximum number of phase repeats to execute (0 for unlimited, max 500)",
+					Required: false,
+					Value:    0,
 				},
 			},
 		}, {

--- a/cmd/chaosmania/main.go
+++ b/cmd/chaosmania/main.go
@@ -51,6 +51,11 @@ func main() {
 					Usage:    "Headers to include in the request",
 					Required: false,
 				},
+				&cli.StringFlag{
+					Name:     "duration",
+					Usage:    "Total duration for the test run (e.g. '1h', '30m', '2h30m')",
+					Required: false,
+				},
 			},
 		}, {
 			Name: "server",

--- a/cmd/chaosmania/main.go
+++ b/cmd/chaosmania/main.go
@@ -52,8 +52,8 @@ func main() {
 					Required: false,
 				},
 				&cli.StringFlag{
-					Name:  "pattern-duration",
-					Usage: "Duration for a single pattern execution (e.g., 1h, 30m). Total runtime will be this duration multiplied by repeats-per-phase.",
+					Name:  "runtime-duration",
+					Usage: "Duration for entire plan divided by phases and repeats equally (e.g., 1h, 30m). Total runtime will be this duration multiplied by repeats-per-phase.",
 					Value: "",
 				},
 				&cli.StringFlag{

--- a/cmd/chaosmania/main.go
+++ b/cmd/chaosmania/main.go
@@ -52,15 +52,19 @@ func main() {
 					Required: false,
 				},
 				&cli.StringFlag{
-					Name:     "total-duration",
-					Usage:    "Total duration for the test run (e.g. '1h', '30m', '2h30m').  Plans with multiple phases will be scaled to fit this duration.",
-					Required: false,
+					Name:  "pattern-duration",
+					Usage: "Duration for a single pattern execution (e.g., 1h, 30m). Total runtime will be this duration multiplied by repeats-per-phase.",
+					Value: "",
+				},
+				&cli.StringFlag{
+					Name:  "phase-pattern",
+					Usage: "Override the phase pattern (sequence, cycle, random)",
+					Value: "",
 				},
 				&cli.IntFlag{
-					Name:     "max-repeats",
-					Usage:    "Maximum number of phase repeats to execute (0 for unlimited, max 500)",
-					Required: false,
-					Value:    0,
+					Name:  "repeats-per-phase",
+					Usage: "Number of times to repeat each phase (0 for unlimited, max 500)",
+					Value: 0,
 				},
 			},
 		}, {

--- a/cmd/chaosmania/main.go
+++ b/cmd/chaosmania/main.go
@@ -64,7 +64,7 @@ func main() {
 				&cli.IntFlag{
 					Name:  "repeats-per-phase",
 					Usage: "Number of times to repeat each phase (0 for unlimited, max 500)",
-					Value: 0,
+					Value: -1,
 				},
 			},
 		}, {

--- a/helm/client/templates/job.yaml
+++ b/helm/client/templates/job.yaml
@@ -30,17 +30,17 @@ spec:
           - "--header"
           - {{.Values.chaos.header| quote}}
           {{ end }}
-          {{ if .Values.chaos.pattern-duration }}
+          {{ if hasKey .Values.chaos "pattern_duration" }}
           - "--pattern-duration"
-          - {{.Values.chaos.pattern-duration| quote}}
-          {{ end }}
-          {{ if .Values.chaos.phase-pattern }}
+          - {{.Values.chaos.pattern_duration| quote}}
+          {{ end }}   
+          {{ if hasKey .Values.chaos "phase_pattern" }}
           - "--phase-pattern"
-          - {{.Values.chaos.phase-pattern| quote}}
+          - {{.Values.chaos.phase_pattern| quote}}
           {{ end }}
-          {{ if .Values.chaos.repeats-per-phase }}
+          {{ if hasKey .Values.chaos "repeats_per_phase" }}
           - "--repeats-per-phase"
-          - {{.Values.chaos.repeats-per-phase}}
+          - {{.Values.chaos.repeats_per_phase| quote}}
           {{ end }}
         env:
           {{- include "otel.env" . | nindent 10 }}

--- a/helm/client/templates/job.yaml
+++ b/helm/client/templates/job.yaml
@@ -30,6 +30,18 @@ spec:
           - "--header"
           - {{.Values.chaos.header| quote}}
           {{ end }}
+          {{ if .Values.chaos.pattern-duration }}
+          - "--pattern-duration"
+          - {{.Values.chaos.pattern-duration| quote}}
+          {{ end }}
+          {{ if .Values.chaos.phase-pattern }}
+          - "--phase-pattern"
+          - {{.Values.chaos.phase-pattern| quote}}
+          {{ end }}
+          {{ if .Values.chaos.repeats-per-phase }}
+          - "--repeats-per-phase"
+          - {{.Values.chaos.repeats-per-phase}}
+          {{ end }}
         env:
           {{- include "otel.env" . | nindent 10 }}
           - name: GOMAXPROCS

--- a/helm/client/values.yaml
+++ b/helm/client/values.yaml
@@ -20,6 +20,9 @@ chaos:
   plans: "plans/*.yaml"
   scenarios: "scenarios/**.yaml"
   header: ""
+  pattern-duration: None   # 1h, 30m, 10m, 5m, 1m, 30s, 10s, 5s, 1s
+  phase-pattern: None      # sequence, cycle, random
+  repeats-per-phase: None  # 0 for unlimited, max 500
 
 otlp:
   enabled: false

--- a/helm/client/values.yaml
+++ b/helm/client/values.yaml
@@ -20,9 +20,9 @@ chaos:
   plans: "plans/*.yaml"
   scenarios: "scenarios/**.yaml"
   header: ""
-  pattern-duration: None   # 1h, 30m, 10m, 5m, 1m, 30s, 10s, 5s, 1s
-  phase-pattern: None      # sequence, cycle, random
-  repeats-per-phase: None  # 0 for unlimited, max 500
+  # pattern_duration: ""   # 1h, 30m, 10m, 5m, 1m, 30s, 10s, 5s, 1s
+  # phase_pattern: ""      # sequence, cycle, random
+  # repeats_per_phase: 1   # 0 for unlimited, max 500
 
 otlp:
   enabled: false

--- a/pkg/actions/durations.go
+++ b/pkg/actions/durations.go
@@ -1,0 +1,130 @@
+package actions
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	// MinPhaseDuration is the minimum allowed duration for any phase
+	MinPhaseDuration = 30 * time.Second
+	// MaxPhaseDuration is the maximum allowed duration for any phase
+	MaxPhaseDuration = 672 * time.Hour // 28 days
+)
+
+// PhaseDurations manages duration calculations for phases
+type PhaseDurations struct {
+	// PatternDuration is the total duration for the pattern if overridden
+	PatternDuration time.Duration
+	// plan is the execution plan
+	plan *Plan
+	// repeats is the number of repeats per phase
+	repeats *PhaseRepeats
+	// cachedDurations stores calculated durations for each phase
+	cachedDurations map[int]time.Duration
+	// AdjustedPatternDuration is the actual pattern duration after minimum/maximum validation
+	AdjustedPatternDuration time.Duration
+}
+
+// NewPhaseDurations creates a new PhaseDurations instance
+func NewPhaseDurations(patternDuration time.Duration, plan *Plan, repeats *PhaseRepeats) *PhaseDurations {
+	pd := &PhaseDurations{
+		PatternDuration: patternDuration,
+		plan:            plan,
+		repeats:         repeats,
+		cachedDurations: make(map[int]time.Duration),
+	}
+
+	// Calculate and validate pattern duration if overridden
+	if patternDuration > 0 {
+		totalRepeats := repeats.GetTotalRepeats(len(plan.Phases))
+		minTotalDuration := MinPhaseDuration * time.Duration(totalRepeats)
+		maxTotalDuration := MaxPhaseDuration * time.Duration(totalRepeats)
+
+		if patternDuration < minTotalDuration {
+			pd.AdjustedPatternDuration = minTotalDuration
+		} else if patternDuration > maxTotalDuration {
+			pd.AdjustedPatternDuration = maxTotalDuration
+		} else {
+			pd.AdjustedPatternDuration = patternDuration
+		}
+	}
+
+	return pd
+}
+
+// GetPhaseDuration calculates the duration for a specific phase
+func (pd *PhaseDurations) GetPhaseDuration(phaseIndex int) time.Duration {
+	// Return cached duration if available
+	if duration, ok := pd.cachedDurations[phaseIndex]; ok {
+		return duration
+	}
+
+	var duration time.Duration
+	if pd.PatternDuration > 0 {
+		// With pattern duration override, calculate based on total repeats
+		totalRepeats := pd.repeats.GetTotalRepeats(len(pd.plan.Phases))
+		// Each phase execution gets an equal share of the total duration
+		duration = pd.AdjustedPatternDuration / time.Duration(totalRepeats)
+	} else {
+		// Without override, use the phase's original duration
+		duration = calculatePhaseDuration(pd.plan.Phases[phaseIndex])
+		// If duration is 0 (missing) or below minimum, use minimum
+		if duration == 0 || duration < MinPhaseDuration {
+			duration = MinPhaseDuration
+		}
+	}
+
+	// Enforce maximum duration limit
+	if duration > MaxPhaseDuration {
+		duration = MaxPhaseDuration
+	}
+
+	// Cache the calculated duration
+	pd.cachedDurations[phaseIndex] = duration
+	return duration
+}
+
+// GetTotalDuration calculates the total duration across all phases
+func (pd *PhaseDurations) GetTotalDuration() time.Duration {
+	if pd.PatternDuration > 0 {
+		return pd.AdjustedPatternDuration
+	}
+
+	var total time.Duration
+	for i := range pd.plan.Phases {
+		total += pd.GetPhaseDuration(i) * time.Duration(pd.repeats.GetRepeat(i))
+	}
+	return total
+}
+
+// GetPhaseTotalDuration returns the total duration for a specific phase including repeats
+func (pd *PhaseDurations) GetPhaseTotalDuration(phaseIndex int) time.Duration {
+	return pd.GetPhaseDuration(phaseIndex) * time.Duration(pd.repeats.GetRepeat(phaseIndex))
+}
+
+// String returns a string representation of the phase durations
+func (pd *PhaseDurations) String() string {
+	if pd.PatternDuration > 0 {
+		if pd.AdjustedPatternDuration != pd.PatternDuration {
+			return fmt.Sprintf("Pattern duration: %s (adjusted from %s due to minimum/maximum limits)", pd.AdjustedPatternDuration, pd.PatternDuration)
+		}
+		return fmt.Sprintf("Pattern duration: %s", pd.PatternDuration)
+	}
+
+	var s string
+	for i, phase := range pd.plan.Phases {
+		duration := pd.GetPhaseDuration(i)
+		s += fmt.Sprintf("Phase %d (%s): %s\n", i+1, phase.Name, duration)
+	}
+	return s
+}
+
+// calculatePhaseDuration calculates the total duration for a single phase
+func calculatePhaseDuration(phase Phase) time.Duration {
+	var duration time.Duration
+	for _, w := range phase.Client.Workers {
+		duration += w.Duration
+	}
+	return duration
+}

--- a/pkg/actions/pattern.go
+++ b/pkg/actions/pattern.go
@@ -81,6 +81,12 @@ func NewSequencePattern(numPhases int) *SequencePattern {
 }
 
 func (p *SequencePattern) NextPhase(currentPhase int, phaseExecutions []int, repeats *PhaseRepeats) int {
+	// If current phase hasn't completed its repeats, stay on it
+	if phaseExecutions[currentPhase] < repeats.GetRepeat(currentPhase) {
+		return currentPhase
+	}
+
+	// Move to next phase
 	nextPhase := currentPhase + 1
 	if nextPhase >= p.numPhases {
 		return -1
@@ -98,8 +104,8 @@ func (p *SequencePattern) IsComplete(phaseExecutions []int, repeats *PhaseRepeat
 }
 
 func (p *SequencePattern) ShouldAdvancePhase(currentPhase int, phaseExecutions []int, repeats *PhaseRepeats) bool {
-	// For sequence pattern, always advance after a phase completes
-	return true
+	// For sequence pattern, only advance when current phase has completed its repeats
+	return phaseExecutions[currentPhase] >= repeats.GetRepeat(currentPhase)
 }
 
 // CyclePattern implements cycling through phases

--- a/pkg/actions/pattern.go
+++ b/pkg/actions/pattern.go
@@ -23,6 +23,9 @@ type PhasePatternExecutor interface {
 	NextPhase(currentPhase int, phaseExecutions []int, repeatsPerPhase int) int
 	// IsComplete returns true if all phases have completed their required executions
 	IsComplete(phaseExecutions []int, repeatsPerPhase int) bool
+	// ShouldAdvancePhase returns true if the current phase should advance to the next phase
+	// This is called after a phase completes (either normally or due to timeout)
+	ShouldAdvancePhase(currentPhase int, phaseExecutions []int, repeatsPerPhase int) bool
 }
 
 // SequencePattern implements sequential phase execution
@@ -35,14 +38,11 @@ func NewSequencePattern(numPhases int) *SequencePattern {
 }
 
 func (p *SequencePattern) NextPhase(currentPhase int, phaseExecutions []int, repeatsPerPhase int) int {
-	if repeatsPerPhase > 0 && phaseExecutions[currentPhase] >= repeatsPerPhase {
-		nextPhase := currentPhase + 1
-		if nextPhase >= p.numPhases {
-			return -1
-		}
-		return nextPhase
+	nextPhase := currentPhase + 1
+	if nextPhase >= p.numPhases {
+		return -1
 	}
-	return currentPhase
+	return nextPhase
 }
 
 func (p *SequencePattern) IsComplete(phaseExecutions []int, repeatsPerPhase int) bool {
@@ -54,6 +54,11 @@ func (p *SequencePattern) IsComplete(phaseExecutions []int, repeatsPerPhase int)
 			return false
 		}
 	}
+	return true
+}
+
+func (p *SequencePattern) ShouldAdvancePhase(currentPhase int, phaseExecutions []int, repeatsPerPhase int) bool {
+	// For sequence pattern, always advance after a phase completes
 	return true
 }
 
@@ -86,6 +91,11 @@ func (p *CyclePattern) IsComplete(phaseExecutions []int, repeatsPerPhase int) bo
 			return false
 		}
 	}
+	return true
+}
+
+func (p *CyclePattern) ShouldAdvancePhase(currentPhase int, phaseExecutions []int, repeatsPerPhase int) bool {
+	// For cycle pattern, always advance after a phase completes
 	return true
 }
 
@@ -131,6 +141,11 @@ func (p *RandomPattern) IsComplete(phaseExecutions []int, repeatsPerPhase int) b
 			return false
 		}
 	}
+	return true
+}
+
+func (p *RandomPattern) ShouldAdvancePhase(currentPhase int, phaseExecutions []int, repeatsPerPhase int) bool {
+	// For random pattern, always advance after a phase completes
 	return true
 }
 

--- a/pkg/actions/pattern.go
+++ b/pkg/actions/pattern.go
@@ -1,0 +1,149 @@
+package actions
+
+import (
+	"math/rand"
+	"time"
+)
+
+// PhasePattern defines how phases are executed in sequence
+type PhasePattern string
+
+const (
+	// PatternSequence executes each phase's repeats before moving to the next phase
+	PatternSequence PhasePattern = "sequence"
+	// PatternCycle cycles through all phases before repeating
+	PatternCycle PhasePattern = "cycle"
+	// PatternRandom randomly selects the next phase
+	PatternRandom PhasePattern = "random"
+)
+
+// PhasePatternExecutor defines the interface for executing phase patterns
+type PhasePatternExecutor interface {
+	// NextPhase returns the next phase index to execute, or -1 if no more phases should be executed
+	NextPhase(currentPhase int, phaseExecutions []int, repeatsPerPhase int) int
+	// IsComplete returns true if all phases have completed their required executions
+	IsComplete(phaseExecutions []int, repeatsPerPhase int) bool
+}
+
+// SequencePattern implements sequential phase execution
+type SequencePattern struct {
+	numPhases int
+}
+
+func NewSequencePattern(numPhases int) *SequencePattern {
+	return &SequencePattern{numPhases: numPhases}
+}
+
+func (p *SequencePattern) NextPhase(currentPhase int, phaseExecutions []int, repeatsPerPhase int) int {
+	if repeatsPerPhase > 0 && phaseExecutions[currentPhase] >= repeatsPerPhase {
+		nextPhase := currentPhase + 1
+		if nextPhase >= p.numPhases {
+			return -1
+		}
+		return nextPhase
+	}
+	return currentPhase
+}
+
+func (p *SequencePattern) IsComplete(phaseExecutions []int, repeatsPerPhase int) bool {
+	if repeatsPerPhase <= 0 {
+		return false
+	}
+	for _, execs := range phaseExecutions {
+		if execs < repeatsPerPhase {
+			return false
+		}
+	}
+	return true
+}
+
+// CyclePattern implements cycling through phases
+type CyclePattern struct {
+	numPhases int
+}
+
+func NewCyclePattern(numPhases int) *CyclePattern {
+	return &CyclePattern{numPhases: numPhases}
+}
+
+func (p *CyclePattern) NextPhase(currentPhase int, phaseExecutions []int, repeatsPerPhase int) int {
+	if repeatsPerPhase > 0 && phaseExecutions[currentPhase] >= repeatsPerPhase {
+		nextPhase := (currentPhase + 1) % p.numPhases
+		if p.IsComplete(phaseExecutions, repeatsPerPhase) {
+			return -1
+		}
+		return nextPhase
+	}
+	return (currentPhase + 1) % p.numPhases
+}
+
+func (p *CyclePattern) IsComplete(phaseExecutions []int, repeatsPerPhase int) bool {
+	if repeatsPerPhase <= 0 {
+		return false
+	}
+	for _, execs := range phaseExecutions {
+		if execs < repeatsPerPhase {
+			return false
+		}
+	}
+	return true
+}
+
+// RandomPattern implements random phase selection
+type RandomPattern struct {
+	numPhases int
+	rng       *rand.Rand
+}
+
+func NewRandomPattern(numPhases int) *RandomPattern {
+	return &RandomPattern{
+		numPhases: numPhases,
+		rng:       rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+func (p *RandomPattern) NextPhase(currentPhase int, phaseExecutions []int, repeatsPerPhase int) int {
+	if repeatsPerPhase <= 0 {
+		return p.rng.Intn(p.numPhases)
+	}
+
+	// Find available phases that haven't completed their repeats
+	var availablePhases []int
+	for i, execs := range phaseExecutions {
+		if execs < repeatsPerPhase {
+			availablePhases = append(availablePhases, i)
+		}
+	}
+
+	if len(availablePhases) == 0 {
+		return -1
+	}
+
+	return availablePhases[p.rng.Intn(len(availablePhases))]
+}
+
+func (p *RandomPattern) IsComplete(phaseExecutions []int, repeatsPerPhase int) bool {
+	if repeatsPerPhase <= 0 {
+		return false
+	}
+	for _, execs := range phaseExecutions {
+		if execs < repeatsPerPhase {
+			return false
+		}
+	}
+	return true
+}
+
+// NewPatternExecutor creates a new pattern executor based on the pattern type
+func NewPatternExecutor(pattern PhasePattern, numPhases int) PhasePatternExecutor {
+	switch pattern {
+	case PatternSequence:
+		return NewSequencePattern(numPhases)
+	case PatternCycle:
+		return NewCyclePattern(numPhases)
+	case PatternRandom:
+		return NewRandomPattern(numPhases)
+	default:
+		return NewSequencePattern(numPhases)
+	}
+}

--- a/pkg/actions/pattern.go
+++ b/pkg/actions/pattern.go
@@ -15,6 +15,9 @@ const (
 	PatternCycle PhasePattern = "cycle"
 	// PatternRandom randomly selects the next phase
 	PatternRandom PhasePattern = "random"
+
+	// MaxRepeatsPerPhase is the maximum number of times a phase can be repeated
+	MaxRepeatsPerPhase = 500
 )
 
 // PhaseRepeats defines how many times each phase should be repeated

--- a/pkg/actions/plan.go
+++ b/pkg/actions/plan.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Causely/chaosmania/pkg"
 	"github.com/Causely/chaosmania/pkg/logger"
 	"github.com/rotisserie/eris"
 	"go.uber.org/zap"
@@ -53,7 +54,22 @@ type Plan struct {
 }
 
 func (plan *Plan) Verify() error {
-	for _, phase := range plan.Phases {
+	for i, phase := range plan.Phases {
+		// Verify worker durations
+		for j, worker := range phase.Client.Workers {
+			if worker.Duration == 0 {
+				return fmt.Errorf("phase %d worker %d: duration is required", i+1, j+1)
+			}
+			if worker.Duration < pkg.MinDuration {
+				return fmt.Errorf("phase %d worker %d: duration %v is less than minimum allowed duration %v",
+					i+1, j+1, worker.Duration, pkg.MinDuration)
+			}
+			if worker.Duration > pkg.MaxDuration {
+				return fmt.Errorf("phase %d worker %d: duration %v exceeds maximum allowed duration %v",
+					i+1, j+1, worker.Duration, pkg.MaxDuration)
+			}
+		}
+
 		err := phase.Verify()
 		if err != nil {
 			return err

--- a/pkg/actions/plan.go
+++ b/pkg/actions/plan.go
@@ -58,14 +58,14 @@ func (plan *Plan) Verify() error {
 		// Verify worker durations
 		for j, worker := range phase.Client.Workers {
 			if worker.Duration == 0 {
-				return fmt.Errorf("phase %d worker %d: duration is required", i+1, j+1)
+				return fmt.Errorf("phase %d worker %d: worker duration is required", i+1, j+1)
 			}
 			if worker.Duration < pkg.MinDuration {
-				return fmt.Errorf("phase %d worker %d: duration %v is less than minimum allowed duration %v",
+				return fmt.Errorf("phase %d worker %d: worker duration %v is less than minimum allowed duration %v (this will be adjusted at runtime)",
 					i+1, j+1, worker.Duration, pkg.MinDuration)
 			}
 			if worker.Duration > pkg.MaxDuration {
-				return fmt.Errorf("phase %d worker %d: duration %v exceeds maximum allowed duration %v",
+				return fmt.Errorf("phase %d worker %d: worker duration %v exceeds maximum allowed duration %v (this will be adjusted at runtime)",
 					i+1, j+1, worker.Duration, pkg.MaxDuration)
 			}
 		}

--- a/pkg/actions/plan.go
+++ b/pkg/actions/plan.go
@@ -46,8 +46,10 @@ type Client struct {
 	Workers []Workers `yaml:"workers" json:"workers"`
 }
 
+// Plan defines the structure of a chaos test plan
 type Plan struct {
-	Phases []Phase `json:"phases"`
+	Pattern PhasePattern `yaml:"pattern"`
+	Phases  []Phase      `yaml:"phases"`
 }
 
 func (plan *Plan) Verify() error {

--- a/pkg/actions/reporter.go
+++ b/pkg/actions/reporter.go
@@ -1,0 +1,110 @@
+package actions
+
+import (
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Reporter manages logging and reporting for phase execution
+type Reporter struct {
+	plan      *Plan
+	repeats   *PhaseRepeats
+	durations *PhaseDurations
+	logger    *zap.Logger
+}
+
+// NewReporter creates a new Reporter instance
+func NewReporter(plan *Plan, repeats *PhaseRepeats, durations *PhaseDurations, logger *zap.Logger) *Reporter {
+	return &Reporter{
+		plan:      plan,
+		repeats:   repeats,
+		durations: durations,
+		logger:    logger,
+	}
+}
+
+// LogRuntimeOverrides logs any runtime overrides that were applied
+func (r *Reporter) LogRuntimeOverrides(runtimeDuration time.Duration, repeatsPerPhase int, phasePattern string) {
+	// Log runtime duration override if specified
+	if runtimeDuration > 0 {
+		if r.durations.AdjustedRuntimeDuration != r.durations.RuntimeDuration {
+			r.logger.Info(fmt.Sprintf("Runtime duration override: %s (adjusted from %s due to minimum/maximum limits)",
+				r.durations.AdjustedRuntimeDuration, r.durations.RuntimeDuration))
+		} else {
+			r.logger.Info(fmt.Sprintf("Runtime duration override: %s", r.durations.RuntimeDuration))
+		}
+	}
+
+	// Log repeats override if specified
+	if repeatsPerPhase > 0 {
+		r.logger.Info(fmt.Sprintf("Repeats override: %d repeats per phase", repeatsPerPhase))
+	} else if repeatsPerPhase == 0 {
+		r.logger.Info(fmt.Sprintf("Repeats override: unlimited (capped at maximum %d)", MaxRepeatsPerPhase))
+	}
+
+	// Log pattern override if specified
+	if phasePattern != "" {
+		r.logger.Info(fmt.Sprintf("Phase pattern override: %s", phasePattern))
+	}
+}
+
+// LogPlanSummary logs a summary of the loaded plan
+func (r *Reporter) LogPlanSummary() {
+	// Log plan load success
+	r.logger.Info("Successfully loaded execution plan")
+
+	// Log total summary in a single line
+	totalDuration := r.durations.GetTotalDuration()
+	r.logger.Info(fmt.Sprintf("Plan summary: %d phases, %s total runtime, %s pattern",
+		len(r.plan.Phases), totalDuration, r.plan.Pattern))
+
+	// Log phase details
+	for i := range r.plan.Phases {
+		phase := r.plan.Phases[i]
+		repeats := r.repeats.GetRepeat(i)
+		phaseDuration := r.durations.GetPhaseDuration(i)
+		phaseTotalDuration := r.durations.GetPhaseTotalDuration(i)
+		r.logger.Info(fmt.Sprintf("Phase %d: %s, %d repeats, %s per phase, %s total",
+			i+1, phase.Name, repeats, phaseDuration, phaseTotalDuration))
+	}
+
+	// Add blank line before execution starts
+	r.logger.Info("")
+}
+
+// LogPhaseStart logs the start of a phase
+func (r *Reporter) LogPhaseStart(phaseIndex int) {
+	phase := r.plan.Phases[phaseIndex]
+	phaseDuration := r.durations.GetPhaseDuration(phaseIndex)
+	r.logger.Info(fmt.Sprintf("Starting phase: %s (duration: %s)", phase.Name, phaseDuration))
+}
+
+// PhaseStats holds statistics for phase execution
+type PhaseStats struct {
+	Requests        uint64
+	Errors          uint64
+	AverageDuration time.Duration
+	StatusCodes     map[int]int
+	PhaseStart      time.Time
+	PhaseEnd        time.Time
+}
+
+// LogPhaseEnd logs the end of a phase with statistics
+func (r *Reporter) LogPhaseEnd(phaseIndex int, stats *PhaseStats) {
+	phase := r.plan.Phases[phaseIndex]
+	r.logger.Info("")
+	r.logger.Info(fmt.Sprintf("Phase complete: %s", phase.Name))
+	r.logger.Info(fmt.Sprintf("  Duration: %v", stats.PhaseEnd.Sub(stats.PhaseStart)))
+	r.logger.Info(fmt.Sprintf("  Requests: %v (%v errors)", stats.Requests, stats.Errors))
+	r.logger.Info(fmt.Sprintf("  Average request duration: %v", stats.AverageDuration))
+
+	if len(stats.StatusCodes) > 0 {
+		r.logger.Info("  Status codes:")
+		for code, count := range stats.StatusCodes {
+			r.logger.Info(fmt.Sprintf("    %v: %v", code, count))
+		}
+	}
+	r.logger.Info("")
+}

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -69,14 +69,6 @@ func (duration *Duration) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("invalid duration: %#v", unmarshalledJson)
 	}
 
-	// Validate duration limits
-	if duration.Duration < MinDuration {
-		return fmt.Errorf("duration %v is less than minimum allowed duration %v", duration.Duration, MinDuration)
-	}
-	if duration.Duration > MaxDuration {
-		return fmt.Errorf("duration %v exceeds maximum allowed duration %v", duration.Duration, MaxDuration)
-	}
-
 	return nil
 }
 

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+const (
+	MinDuration = 1 * time.Minute
+	MaxDuration = 28 * 24 * time.Hour
+)
+
 func ConfigToMap[T any](data *T) (map[string]any, error) {
 	jsonString, err := json.Marshal(data)
 	if err != nil {
@@ -62,6 +67,14 @@ func (duration *Duration) UnmarshalJSON(b []byte) error {
 		}
 	default:
 		return fmt.Errorf("invalid duration: %#v", unmarshalledJson)
+	}
+
+	// Validate duration limits
+	if duration.Duration < MinDuration {
+		return fmt.Errorf("duration %v is less than minimum allowed duration %v", duration.Duration, MinDuration)
+	}
+	if duration.Duration > MaxDuration {
+		return fmt.Errorf("duration %v exceeds maximum allowed duration %v", duration.Duration, MaxDuration)
 	}
 
 	return nil

--- a/scenarios/chained-cpu-congestion/run.sh
+++ b/scenarios/chained-cpu-congestion/run.sh
@@ -1,66 +1,21 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-chained-cpu-congestion
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "frontend" "$NAMESPACE" "$SCENARIO" "$SCRIPT_DIR" "--set" "replicaCount=2"
+upgrade_single "payment-service" "$NAMESPACE" "$SCENARIO" "$SCRIPT_DIR" "--set" "replicaCount=1" "--set" "resources.limits.cpu=1000m"
+upgrade_single "order-service" "$NAMESPACE" "$SCENARIO" "$SCRIPT_DIR" "--set" "replicaCount=2"
 
-
-echo "Deploying frontend"
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=2 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    frontend $SCRIPT_DIR/../../helm/single 
-
-echo "Deploying payment"
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=1 \
-    --set resources.limits.cpu="1000m"\
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    payment-service $SCRIPT_DIR/../../helm/single 
-
-echo "Deploying orders"
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=2 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    order-service $SCRIPT_DIR/../../helm/single 
-
-echo "Deploying client"
-helm delete --namespace $NAMESPACE client || true
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.host=frontend \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
+# Deploy client
+upgrade_client "$NAMESPACE" "$SCENARIO" "$SCRIPT_DIR" "client" "frontend" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/chained-services-db-unavailable/run.sh
+++ b/scenarios/chained-services-db-unavailable/run.sh
@@ -1,57 +1,22 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-chained-services-db-unavailable
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "frontend" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "replicaCount=2"
+upgrade_single "payment" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "replicaCount=2"
 
-echo "Deploying frontend"
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=2 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    frontend $SCRIPT_DIR/../../helm/single 
+# Do not deploy DB
 
-echo "Deploying payment"
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=2 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    payment $SCRIPT_DIR/../../helm/single 
-
-echo "Deploying client"
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.host=frontend \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "frontend" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/chained-services/run.sh
+++ b/scenarios/chained-services/run.sh
@@ -1,49 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-chained-services
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
-
-echo "Deploying frontend"
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=2 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    frontend $SCRIPT_DIR/../../helm/single 
-
-echo "Deploying payment"
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=2 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    payment $SCRIPT_DIR/../../helm/single 
+# Deploy single instance
+upgrade_single "frontend" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "replicaCount=2"
+upgrade_single "payment" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "replicaCount=2"
 
 echo "Deploying DB"
 helm upgrade --install --namespace $NAMESPACE \
@@ -52,6 +23,7 @@ helm upgrade --install --namespace $NAMESPACE \
     postgres oci://registry-1.docker.io/bitnamicharts/postgresql
     # --set commonLabels.app\.kubernetes\.io/part-of=$NAMESPACE \
 
+echo "Deploying postgres-exporter"
 helm upgrade --install --namespace $NAMESPACE \
     --set serviceMonitor.enabled=true \
     --set config.datasource.host=postgres-postgresql \
@@ -59,13 +31,5 @@ helm upgrade --install --namespace $NAMESPACE \
     --set config.datasource.user=postgres \
     postgres-exporter prometheus-community/prometheus-postgres-exporter
 
-echo "Deploying client"
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.host=frontend \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "frontend" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/client-throttled/run.sh
+++ b/scenarios/client-throttled/run.sh
@@ -1,55 +1,23 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-client-throttled
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "resources.limits.cpu=500m" "--set" "replicaCount=3"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set resources.limits.cpu="500m"\
-    --set replicaCount=3 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
+# Deploy throttled client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client-throttled" "single" "/scenarios/$SCENARIO-throttled.yaml"
 
-helm delete --namespace $NAMESPACE client-throttled
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-throttled.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client-throttled $SCRIPT_DIR/../../helm/client
-
-helm delete --namespace $NAMESPACE client-not-throttled
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-not_throttled.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client-not-throttled $SCRIPT_DIR/../../helm/client
+# Deploy non-throttled client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client-not-throttled" "single" "/scenarios/$SCENARIO-not_throttled.yaml"
 

--- a/scenarios/client-unauthorized/run.sh
+++ b/scenarios/client-unauthorized/run.sh
@@ -1,55 +1,22 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-client-unauthorized
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "resources.limits.cpu=500m" "--set" "replicaCount=3"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set resources.limits.cpu="500m"\
-    --set replicaCount=3 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client-unauthorized" "single" "/scenarios/$SCENARIO-unauthorized.yaml"
 
-helm delete --namespace $NAMESPACE client-unauthorized
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-unauthorized.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client-unauthorized $SCRIPT_DIR/../../helm/client
-
-helm delete --namespace $NAMESPACE client-not-unauthorized
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-not_unauthorized.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client-not-unauthorized $SCRIPT_DIR/../../helm/client
-
+# Deploy non-authorized client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client-not-unauthorized" "single" "/scenarios/$SCENARIO-not_unauthorized.yaml"

--- a/scenarios/container-cpu-congestion/run.sh
+++ b/scenarios/container-cpu-congestion/run.sh
@@ -1,48 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-container-cpu-congestion
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "resources.limits.cpu=500m" "--set" "replicaCount=3"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set resources.limits.cpu="500m"\
-    --set replicaCount=3 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.host=single.$NAMESPACE.svc.cluster.local. \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"
 

--- a/scenarios/container-data-disk-tp-throttled/run.sh
+++ b/scenarios/container-data-disk-tp-throttled/run.sh
@@ -1,48 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-container-data-disk-tp-throttled
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "replicaCount=1" "--set" "persistence.enabled=true" "--set" "persistence.size=100Gi"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=1 \
-    --set persistence.enabled=true \
-    --set persistence.size=100Gi \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/ephemeral-storage-eviction/run.sh
+++ b/scenarios/ephemeral-storage-eviction/run.sh
@@ -1,48 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-ephemeral-storage-eviction
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "resources.limits.ephemeral-storage=256Mi" "--set" "securityContext.readOnlyRootFilesystem=false" "--set" "replicaCount=3"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set resources.limits.ephemeral-storage=256Mi \
-    --set securityContext.readOnlyRootFilesystem=false \
-    --set replicaCount=3 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/ndots-nxdomain/run.sh
+++ b/scenarios/ndots-nxdomain/run.sh
@@ -1,46 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-ndots-nxdomain
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "resources.limits.cpu=500m" "--set" "replicaCount=3"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set resources.limits.cpu="500m"\
-    --set replicaCount=3 \
-    --set business_application=$SCENARIO \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set chaos.host=single.$NAMESPACE.svc.cluster.local \
-    --set business_application=$SCENARIO \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/node-cpu-congestion/run.sh
+++ b/scenarios/node-cpu-congestion/run.sh
@@ -1,46 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-node-cpu-congestion
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "replicaCount=1"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=1 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/node-ephemeral-storage-eviction/run.sh
+++ b/scenarios/node-ephemeral-storage-eviction/run.sh
@@ -1,47 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-node-ephemeral-storage-eviction
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "resources.limits.ephemeral-storage=256Mi" "--set" "securityContext.readOnlyRootFilesystem=false" "--set" "replicaCount=3"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set securityContext.readOnlyRootFilesystem=false \
-    --set replicaCount=3 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/node-oom-eviction/run.sh
+++ b/scenarios/node-oom-eviction/run.sh
@@ -1,45 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-node-oom-eviction
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "replicaCount=3"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=3 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/noisy-client-cpu-congestion/run.sh
+++ b/scenarios/noisy-client-cpu-congestion/run.sh
@@ -1,63 +1,21 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-noisy-client-cpu-congestion
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "resources.limits.cpu=500m" "--set" "replicaCount=3"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set resources.limits.cpu="500m"\
-    --set replicaCount=3 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client1
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan1.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client1 $SCRIPT_DIR/../../helm/client
-
-helm delete --namespace $NAMESPACE client2
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan2.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client2 $SCRIPT_DIR/../../helm/client
-
-helm delete --namespace $NAMESPACE client3
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan3.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client3 $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client1" "single" "/scenarios/$SCENARIO-plan1.yaml"
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client2" "single" "/scenarios/$SCENARIO-plan2.yaml"
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client3" "single" "/scenarios/$SCENARIO-plan3.yaml"

--- a/scenarios/periodical-crash/run.sh
+++ b/scenarios/periodical-crash/run.sh
@@ -1,47 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-periodical-crash
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "resources.limits.memory=256Mi" "--set" "replicaCount=3"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set resources.limits.memory=256Mi \
-    --set replicaCount=3 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/periodical-oom/run.sh
+++ b/scenarios/periodical-oom/run.sh
@@ -1,47 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-periodical-oom
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "resources.limits.memory=256Mi" "--set" "replicaCount=3"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set resources.limits.memory=256Mi \
-    --set replicaCount=3 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/postgres-db-many-queries/run.sh
+++ b/scenarios/postgres-db-many-queries/run.sh
@@ -1,46 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-postgres-db-many-queries
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "replicaCount=1"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=1 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/queuing-theory/run.sh
+++ b/scenarios/queuing-theory/run.sh
@@ -1,46 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-queuing-theory
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "resources.limits.cpu=1000m"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set resources.limits.cpu="1000m"\
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/simple-kafka/run.sh
+++ b/scenarios/simple-kafka/run.sh
@@ -1,33 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-simple-kafka
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
-
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Setup namespace
+setup_namespace $SCENARIO
 
 echo
 echo "Deploying Kafka"
@@ -36,73 +19,51 @@ helm upgrade --install --namespace $NAMESPACE \
 
 PASSWORD=$(kubectl get secret my-kafka-user-passwords --namespace $NAMESPACE -o jsonpath='{.data.client-passwords}' | base64 -d | cut -d , -f 1)
 
-echo
-echo "Deploying producer"
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=1 \
-    --set business_application=$SCENARIO \
-    --set services[0].name=kafka-producer \
-    --set services[0].type=kafka-producer \
-    --set services[0].config.peer_service=kafka \
-    --set services[0].config.peer_namespace=$SCENARIO \
-    --set services[0].config.brokers[0]=my-kafka-controller-0.my-kafka-controller-headless.$SCENARIO.svc.cluster.local:9092 \
-    --set services[0].config.brokers[1]=my-kafka-controller-1.my-kafka-controller-headless.$SCENARIO.svc.cluster.local:9092 \
-    --set services[0].config.brokers[2]=my-kafka-controller-2.my-kafka-controller-headless.$SCENARIO.svc.cluster.local:9092 \
-    --set services[0].config.username=user1 \
-    --set services[0].config.password="$PASSWORD" \
-    --set services[0].config.tls_enable=false \
-    --set services[0].config.sasl_enable=true \
-    --set otlp.enabled=true \
-    producer $SCRIPT_DIR/../../helm/single 
+# Deploy single instance
+upgrade_single "producer" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "replicaCount=1" \
+    "--set" "services[0].name=kafka-producer" \
+    "--set" "services[0].type=kafka-producer" \
+    "--set" "services[0].config.peer_service=kafka" \
+    "--set" "services[0].config.peer_namespace=$SCENARIO" \
+    "--set" "services[0].config.brokers[0]=my-kafka-controller-0.my-kafka-controller-headless.$SCENARIO.svc.cluster.local:9092" \
+    "--set" "services[0].config.brokers[1]=my-kafka-controller-1.my-kafka-controller-headless.$SCENARIO.svc.cluster.local:9092" \
+    "--set" "services[0].config.brokers[2]=my-kafka-controller-2.my-kafka-controller-headless.$SCENARIO.svc.cluster.local:9092" \
+    "--set" "services[0].config.username=user1" \
+    "--set" "services[0].config.password=$PASSWORD" \
+    "--set" "services[0].config.tls_enable=false" \
+    "--set" "services[0].config.sasl_enable=true"
 
-echo
-echo "Deploying consumer"
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set replicaCount=1 \
-    --set business_application=$SCENARIO \
-    --set background_services[0].name=kafka-consumer \
-    --set background_services[0].type=kafka-consumer \
-    --set background_services[0].config.peer_service=kafka \
-    --set background_services[0].config.peer_namespace=$SCENARIO \
-    --set background_services[0].config.brokers[0]=my-kafka.$SCENARIO.svc.cluster.local:9092 \
-    --set background_services[0].config.username=user1 \
-    --set background_services[0].config.password="$PASSWORD" \
-    --set background_services[0].config.tls_enable=false \
-    --set background_services[0].config.sasl_enable=true \
-    --set background_services[0].config.topic=test1 \
-    --set background_services[0].config.group=my-consumer-group \
-    --set background_services[0].config.script="function run() { var msg = ctx.get_message(); ctx.print('Received message: ' + msg); }" \
-    --set enabled_background_services[0]="kafka-consumer" \
-    --set otlp.enabled=true \
-    consumer $SCRIPT_DIR/../../helm/single 
+upgrade_single "consumer" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "replicaCount=1" \
+    "--set" "background_services[0].name=kafka-consumer" \
+    "--set" "background_services[0].type=kafka-consumer" \
+    "--set" "background_services[0].config.peer_service=kafka" \
+    "--set" "background_services[0].config.peer_namespace=$SCENARIO" \
+    "--set" "background_services[0].config.brokers[0]=my-kafka.$SCENARIO.svc.cluster.local:9092" \
+    "--set" "background_services[0].config.username=user1" \
+    "--set" "background_services[0].config.password=$PASSWORD" \
+    "--set" "background_services[0].config.tls_enable=false" \
+    "--set" "background_services[0].config.sasl_enable=true" \
+    "--set" "background_services[0].config.topic=test1" \
+    "--set" "background_services[0].config.group=my-consumer-group" \
+    "--set" "background_services[0].config.script=\"function run() { var msg = ctx.get_message(); ctx.print('Received message: ' + msg); }\"" \
+    "--set" "enabled_background_services[0]=kafka-consumer"
 
 echo
 echo "Deploying exporter"
 helm upgrade --install --namespace $NAMESPACE \
-    --set prometheus.serviceMonitor.enabled=true \
-    --set kafkaServer[0]=my-kafka-controller-0.my-kafka-controller-headless.$SCENARIO.svc.cluster.local:9092 \
-    --set sasl.enabled=true \
-    --set sasl.scram.enabled=true \
-    --set sasl.scram.mechanism=scram-sha256 \
-    --set sasl.scram.username=user1 \
-    --set sasl.scram.password="$PASSWORD" \
-    --set prometheus.serviceMonitor.enabled=true \
-    --set prometheus.serviceMonitor.namespace=$SCENARIO \
-    --set prometheus.serviceMonitor.relabelings[0].action=replace \
-    --set prometheus.serviceMonitor.relabelings[0].replacement=my-kafka.$SCENARIO.svc.cluster.local:9092 \
-    --set prometheus.serviceMonitor.relabelings[0].targetLabel=target \
+    "--set" "prometheus.serviceMonitor.enabled=true" \
+    "--set" "kafkaServer[0]=my-kafka-controller-0.my-kafka-controller-headless.$SCENARIO.svc.cluster.local:9092" \
+    "--set" "sasl.enabled=true" \
+    "--set" "sasl.scram.enabled=true" \
+    "--set" "sasl.scram.mechanism=scram-sha256" \
+    "--set" "sasl.scram.username=user1" \
+    "--set" "sasl.scram.password=$PASSWORD" \
+    "--set" "prometheus.serviceMonitor.enabled=true" \
+    "--set" "prometheus.serviceMonitor.namespace=$SCENARIO" \
+    "--set" "prometheus.serviceMonitor.relabelings[0].action=replace" \
+    "--set" "prometheus.serviceMonitor.relabelings[0].replacement=my-kafka.$SCENARIO.svc.cluster.local:9092" \
+    "--set" "prometheus.serviceMonitor.relabelings[0].targetLabel=target" \
     kafka-exporter prometheus-community/prometheus-kafka-exporter
 
-echo
-echo "Deploying client"
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.host=producer \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "producer" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/snowflake-query/run.sh
+++ b/scenarios/snowflake-query/run.sh
@@ -1,47 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/../../scripts/lib/chaosmania.sh
 
-# Parse command line arguments
-PREFIX_USER=false
-for arg in "$@"; do
-    case $arg in
-        --prefix-user)
-            PREFIX_USER=true
-            shift
-            ;;
-    esac
-done
+# Parse arguments
+parse_args "$@"
 
-IMAGE_REPO=quay.io/causely/chaosmania
-IMAGE_TAG=latest
+# Setup scenario
 SCENARIO=cm-snowflake-query
-# Set namespace based on --prefix-user flag
-if [ "$PREFIX_USER" = true ]; then
-    NAMESPACE=$USER-$SCENARIO
-else
-    NAMESPACE=$SCENARIO
-fi
 
-echo "Creating namespace $NAMESPACE"
-kubectl create namespace $NAMESPACE || true
+# Setup namespace
+setup_namespace $SCENARIO
 
-echo "Labeling namespace $NAMESPACE for Istio injection"
-kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+# Deploy single instance
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "resources.limits.memory=256Mi" "--set" "replicaCount=1"
 
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set resources.limits.memory=256Mi \
-    --set replicaCount=1 \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    single $SCRIPT_DIR/../../helm/single 
-
-helm delete --namespace $NAMESPACE client
-helm upgrade --install --namespace $NAMESPACE \
-    --set image.tag=$IMAGE_TAG \
-    --set chaos.plan=/scenarios/$SCENARIO-plan.yaml \
-    --set business_application=$SCENARIO \
-    --set otlp.enabled=true \
-    client $SCRIPT_DIR/../../helm/client
-
+# Deploy client
+upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"

--- a/scripts/lib/chaosmania.sh
+++ b/scripts/lib/chaosmania.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Common variables
+IMAGE_REPO=quay.io/causely/chaosmania
+IMAGE_TAG=latest
+
+# Parse common command line arguments
+parse_args() {
+    PREFIX_USER=false
+    REPEATS_PER_PHASE=""
+    PHASE_PATTERN=""
+    PATTERN_DURATION=""
+
+    for arg in "$@"; do
+        case $arg in
+            --prefix-user)
+                export PREFIX_USER=true
+                shift
+                ;;
+            --repeats-per-phase)
+                export REPEATS_PER_PHASE=$2
+                shift 2
+                ;;
+            --phase-pattern)
+                export PHASE_PATTERN=$2
+                shift 2
+                ;;
+            --pattern-duration)
+                export PATTERN_DURATION=$2
+                shift 2
+                ;;
+        esac
+    done
+}
+
+# Setup namespace
+setup_namespace() {
+    local SCENARIO=$1
+
+    if [ "$PREFIX_USER" = true ]; then
+        export NAMESPACE=$USER-$SCENARIO
+    else
+        export NAMESPACE=$SCENARIO
+    fi
+
+    echo "Creating namespace $NAMESPACE"
+    kubectl create namespace $NAMESPACE || true
+
+    echo "Labeling namespace $NAMESPACE for Istio injection"
+    kubectl label namespace $NAMESPACE istio-injection=enabled --overwrite || true
+}
+
+# Build client arguments
+build_client_args() {
+    local CLIENT_ARGS=""
+    if [ ! -z "$REPEATS_PER_PHASE" ]; then
+        CLIENT_ARGS="$CLIENT_ARGS --set chaos.repeats_per_phase=$REPEATS_PER_PHASE"
+    fi
+    if [ ! -z "$PHASE_PATTERN" ]; then
+        CLIENT_ARGS="$CLIENT_ARGS --set chaos.phase_pattern=$PHASE_PATTERN"
+    fi
+    if [ ! -z "$PATTERN_DURATION" ]; then
+        CLIENT_ARGS="$CLIENT_ARGS --set chaos.pattern_duration=$PATTERN_DURATION"
+    fi
+    echo "$CLIENT_ARGS"
+}
+
+# Common helm upgrade command for single deployment
+upgrade_single() {
+    local DEPLOYMENT_NAME=$1
+    local NAMESPACE=$2
+    local SCENARIO=$3
+    local SCRIPT_DIR=$4
+    shift 4  # Remove the first 4 arguments
+    local EXTRA_ARGS=("$@")  # Capture all remaining arguments as an array
+
+    echo "Deploying $DEPLOYMENT_NAME"
+    helm upgrade --install --namespace $NAMESPACE \
+        --set image.tag=$IMAGE_TAG \
+        --set business_application=$SCENARIO \
+        --set otlp.enabled=true \
+        "${EXTRA_ARGS[@]}" \
+        $DEPLOYMENT_NAME $SCRIPT_DIR/../../helm/single
+}
+
+# Common helm upgrade command for client deployment
+upgrade_client() {
+    local NAMESPACE=$1
+    local SCENARIO=$2
+    local SCRIPT_DIR=$3
+    local CLIENT_NAME=$4
+    local CHAOS_HOST=$5
+    local PLAN_PATH=$6
+    shift 6  # Remove the first 6 arguments
+    local EXTRA_ARGS=${7:-}
+
+    echo "Deploying client $CLIENT_NAME"
+    helm delete --namespace $NAMESPACE $CLIENT_NAME || true
+    helm upgrade --install --namespace $NAMESPACE \
+        --set image.tag=$IMAGE_TAG \
+        --set chaos.host=$CHAOS_HOST.$NAMESPACE.svc.cluster.local \
+        --set chaos.plan=$PLAN_PATH \
+        --set business_application=$SCENARIO \
+        --set otlp.enabled=true \
+        $(build_client_args) \
+        $EXTRA_ARGS \
+        $CLIENT_NAME $SCRIPT_DIR/../../helm/client
+}
+
+# Debug mode - set to true to enable command echoing
+DEBUG=${DEBUG:-false}
+if [ "$DEBUG" = true ]; then
+    PS4='+(${BASH_SOURCE}:${LINENO}): '
+    set -x
+fi


### PR DESCRIPTION
# Description

- Add flags for client to override the plan repeat and duration values.
- DRY out run.sh scripts
- Add support for repeat patterns:
    - cycle: perform each phase once, then repeat based on repeat values.
    - sequence: the original pattern
    - random: Select from available phases with repeats left and run that phase, then choose at random again.
- Clean up logging

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
