### PR TITLE
[DEV-3162] Fix cluster nxdomain lookup errors.

### DIFF
--- a/scenarios/client-unauthorized/unauthorized.yaml
+++ b/scenarios/client-unauthorized/unauthorized.yaml
@@ -11,9 +11,15 @@ phases:
 
     workload:
       actions:
-        - name: Burn
+        # Send request to single service
+        - name: HTTPRequest
           config:
-            duration: 1ms
-        - name: HTTPResponse
-          config:
-            statusCode: 401
+            url: http://single:8080
+            body:
+              actions:
+                - name: Burn
+                  config:
+                    duration: 1ms
+                - name: HTTPResponse
+                  config:
+                    statusCode: 401

--- a/scripts/lib/chaosmania.sh
+++ b/scripts/lib/chaosmania.sh
@@ -98,7 +98,7 @@ upgrade_client() {
     helm delete --namespace $NAMESPACE $CLIENT_NAME || true
     helm upgrade --install --namespace $NAMESPACE \
         --set image.tag=$IMAGE_TAG \
-        --set chaos.host=$CHAOS_HOST.$NAMESPACE.svc.cluster.local \
+        --set chaos.host=$CHAOS_HOST.$NAMESPACE.svc.cluster.local. \
         --set chaos.plan=$PLAN_PATH \
         --set business_application=$SCENARIO \
         --set otlp.enabled=true \


### PR DESCRIPTION
# Description

- Terminate chaos host in client configs to prevent unnecessary dns lookups.
- Start the unauthorized workload as an HTTP request to help with span detection.

Fixes # 3162

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
