### PR TITLE
Disable datadoghq labels if datadog is not enabled.

### DIFF
--- a/helm/single/templates/deployment.yaml
+++ b/helm/single/templates/deployment.yaml
@@ -24,9 +24,11 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/name: {{ .Release.Name }}
         app.kubernetes.io/part-of: {{ .Values.business_application }}
+        {{ if .Values.datadog.enabled }}
         tags.datadoghq.com/env: test
         tags.datadoghq.com/service: {{ include "single.fullname" . }}
         tags.datadoghq.com/version: "1"
+        {{ end }}
     spec:
       {{- if .Values.nodeName }}
       nodeSelector:


### PR DESCRIPTION
# Description

This resulted in duplication of network endpoints and http path entities

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

