### PR TITLE
[DEV-3162] Adjust node-cpu-congestion limits

### DIFF
--- a/scenarios/node-cpu-congestion/run.sh
+++ b/scenarios/node-cpu-congestion/run.sh
@@ -13,7 +13,7 @@ SCENARIO=cm-node-cpu-congestion
 setup_namespace $SCENARIO
 
 # Deploy single instance
-upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "replicaCount=1"
+upgrade_single "single" $NAMESPACE $SCENARIO $SCRIPT_DIR "--set" "resources.limits.cpu=500m" "--set" "replicaCount=1"
 
 # Deploy client
 upgrade_client $NAMESPACE $SCENARIO $SCRIPT_DIR "client" "single" "/scenarios/$SCENARIO-plan.yaml"

--- a/scenarios/postgres-cpu-congestion/run.sh
+++ b/scenarios/postgres-cpu-congestion/run.sh
@@ -15,7 +15,7 @@ setup_namespace $SCENARIO
 echo "Deploying DB"
 helm upgrade --install --namespace $NAMESPACE \
     --set global.postgresql.auth.postgresPassword=postgres \
-    --set commonLabels."app\.kubernetes\.io/part-of"=$NAMESPACE \
+    --set commonLabels."app\.kubernetes\.io/part-of"=$SCENARIO \
     --set primary.resources.limits.cpu=400m \
     -f $SCRIPT_DIR/postgres_values.yaml \
     postgres oci://registry-1.docker.io/bitnamicharts/postgresql
@@ -55,9 +55,9 @@ kubectl create secret generic \
     --namespace $NAMESPACE \
     --from-literal=username="postgres" \
     --from-literal=password="postgres" \
-    --from-literal=host="postgres-postgresql.$NAMESPACE.svc.cluster.local" \
+    --from-literal=host="postgres-postgresql" \
     --from-literal=port=5432 \
     --from-literal=database="postgres" \
-    $NAMESPACE-postgres-credentials | kubectl apply -f -
+    $SCENARIO-postgres-credentials | kubectl apply -f -
 
-kubectl label secret $NAMESPACE-postgres-credentials --namespace $NAMESPACE "causely.ai/scraper=Postgresql" --overwrite
+kubectl label secret $SCENARIO-postgres-credentials --namespace $NAMESPACE "causely.ai/scraper=Postgresql" --overwrite


### PR DESCRIPTION
# Description

- Adjust node-cpu-congestion limits down to 500m
- Use SCENARIO instead of NAMESPACE for cleaner Kubernetes artifacts and labels.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Requires a database migration
- [ ] Documentation has been updated
- [ ] Any dependent changes have been merged and published in downstream modules / repositories
