### PR TITLE
Fix: Increase productcatalog CPU resources to handle traffic congestion

### DIFF
--- a/helm/boutique/values.yaml
+++ b/helm/boutique/values.yaml
@@ -5,11 +5,11 @@ image:
 
 resources:
   limits:
-    cpu: 4000m
+    cpu: 6000m
     memory: 4Gi
   requests:
-    cpu: 10m
-    memory: 64Mi
+    cpu: 1000m
+    memory: 512Mi
 
 serviceMonitor:
   # When set true then use a serviceMonitor to configure scraping


### PR DESCRIPTION
## Problem
CPU congestion has been identified as an active root cause affecting the `chaosmania/productcatalog/chaosmania` entity since Oct 2 20:23.

## Solution
This PR increases the CPU resources for the productcatalog service in the boutique helm chart to better handle extra traffic:

### Changes Made:
- **CPU Request**: Increased from 10m to 1000m (100x increase)
  - This ensures Kubernetes scheduler allocates sufficient CPU resources upfront
- **CPU Limit**: Increased from 4000m to 6000m (50% increase)  
  - This allows the service to handle peak traffic loads
- **Memory Request**: Increased from 64Mi to 512Mi (8x increase)
  - This provides better performance and reduces memory pressure

### Impact:
- Resolves CPU congestion root cause
- Improves service performance under load
- Better resource allocation by Kubernetes scheduler
- Reduces likelihood of CPU throttling

## Testing
Deploy the updated helm chart to see CPU congestion resolution in Causely monitoring.