### PR TITLE
Switch Kafka Helm chart from Bitnami to SolDevelo

### DIFF
--- a/scenarios/simple-kafka/run.sh
+++ b/scenarios/simple-kafka/run.sh
@@ -15,7 +15,7 @@ setup_namespace $SCENARIO
 echo
 echo "Deploying Kafka"
 helm upgrade --install --namespace $NAMESPACE \
-    my-kafka oci://registry-1.docker.io/bitnamicharts/kafka
+    my-kafka oci://registry-1.docker.io/soldevelo/kafka-chart
 
 PASSWORD=$(kubectl get secret my-kafka-user-passwords --namespace $NAMESPACE -o jsonpath='{.data.client-passwords}' | base64 -d | cut -d , -f 1)
 


### PR DESCRIPTION
This PR replaces the Bitnami Kafka image used in our Helm installation script with the SolDevelo-maintained, fully open-source, paywall-free Kafka image.
The change ensures that our deployment remains publicly accessible and free from vendor paywall limitations introduced by Bitnami.

This update:
* Prevents future deployment failures related to Bitnami paywalling
* Ensures continued free and public access to Kafka images
* Retains compatibility with existing configurations
* Requires no breaking changes for users